### PR TITLE
docs: migrate approved Reddit megathreads

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,30 @@ The Reddit posts are good for discussion and visibility. This repo is for keepin
 
 ## Megathreads
 
-- [Free Models and APIs for Hermes Agent — June 2026](megathreads/free-models-apis-2026-06.md)
-- [How to Set Up Hermes Agent from Scratch — July 2026 (Beginner Guide)](megathreads/beginner-setup-2026-07.md)
+### Start here
+
+- [How to Set Up Hermes Agent from Scratch — July 2026](megathreads/beginner-setup-2026-07.md)
+- [Agent Trust Boundary — July 2026](megathreads/agent-trust-boundary-2026-07.md)
+
+### Operations and architecture
+
+- [Integrations, Plugins, and Skills Ecosystem — June 2026](megathreads/integrations-plugins-skills-2026-06.md)
+- [Kanban Setups — June 2026](megathreads/kanban-setups-2026-06.md)
+- [Multi-Agent and Profiles — June 2026](megathreads/multi-agent-profiles-2026-06.md)
+- [VPS and Deployment — June 2026](megathreads/vps-deployment-2026-06.md)
+- [Cost and Token Optimization — June 2026](megathreads/cost-token-optimization-2026-06.md)
+
+### Models and providers
+
+- [Free Models and APIs — Historical June 2026 snapshot, reviewed July 2026](megathreads/free-models-apis-2026-06.md)
+- [Models, Providers, and Plans — July 2026](megathreads/models-providers-plans-2026-07.md)
+- [Mac and MLX on Apple Silicon — June 2026](megathreads/mac-mlx-apple-silicon-2026-06.md)
+- [Qwen3.6-27B Community Variants — Historical guide, July 2026](megathreads/qwen3.6-27b-community-variants-2026-07.md)
+- [Qwen3.6-35B-A3B Community Variants — Historical guide, July 2026](megathreads/qwen3.6-35b-a3b-community-variants-2026-07.md)
+
+### Community catalog
+
+- [Hermes Agent Use Cases — July 2026](megathreads/hermes-agent-use-cases-2026-07.md)
 
 ## How to suggest an update
 

--- a/megathreads/agent-trust-boundary-2026-07.md
+++ b/megathreads/agent-trust-boundary-2026-07.md
@@ -1,0 +1,227 @@
+# Agent Trust Boundary Megathread — July 2026
+
+> Original Reddit thread (kept as source): https://www.reddit.com/r/hermesagent/comments/1usz3d3/agent_trust_boundary_megathread_connect_the_tools/
+>
+> **Status:** Canonical maintenance version for `r/hermesagent` safety/operator patterns
+>
+> **Last Updated:** July 16, 2026
+>
+> **Scope:** Build a practical permission model for Hermes without over-connecting personal, work, and production systems.
+
+This guide is extracted from the source post and updated with comment-derived corrections and verified official documentation.
+
+---
+
+## 1) Why this exists
+
+Hermes is useful because it can act through tools, not because it should receive unrestricted access to your identity, finance, or production systems.
+
+A trust boundary is the operational design that decides:
+
+- Which accounts the agent can touch
+- Which tools are available
+- Which actions are irreversible and always human-confirmed
+- How quickly you can revoke access when something goes wrong
+
+The post framing is intentionally removed for this guide; this is the reusable operating standard.
+
+---
+
+## 2) Operator rules (baseline)
+
+1. Do not paste raw passwords into chat. Use OAuth, bot tokens, app passwords, scoped API keys, or dedicated accounts.
+2. Start with read-only access. Add write capability only when the workflow truly requires it.
+3. Prefer agent-owned identities (Hermes mailbox/profile, bot accounts, dedicated browser profile, sandbox user) for each major app domain.
+4. Gate all irreversible actions: spending, payroll, deletes, posts from a real identity, production changes, legal/medical/HR actions.
+5. Review plugins, MCP servers, and toolsets before enabling them.
+6. Treat messaging gateways as direct input surfaces. A DM/mention channel can trigger tool execution.
+7. Keep secrets outside chat and use provider secret managers where available.
+8. Keep a remove-and-revoke plan ready before expanding access.
+9. Never rely on one-size-fits-all trust settings. Boundaries differ by workflow and account criticality.
+10. Follow workplace policy. If a system is managed by IT, start with a compliant pilot and read-only/sanitized data.
+
+---
+
+## 3) What is verified from Hermes docs (as of 2026-07-16)
+
+### 3.1 Security layers (verified)
+
+Hermes security docs define an explicit multi-layer model including user authorization, dangerous command approval, file-write safeguards, container isolation, MCP credential handling, context/file scanning, session isolation, and input sanitization.
+
+- Security page: [user-guide/security/](https://hermes-agent.nousresearch.com/docs/user-guide/security/)
+
+### 3.2 Approval controls (verified)
+
+- `approvals.mode` supports **smart**, **manual**, and **off**. A distinct **hardline blocklist** still blocks destructive commands (for example catastrophic deletes, fork bombs, root-wipe patterns), even in YOLO/off modes.
+- `approvals.deny` is available for organization-level deny rules.
+- `--yolo` is available for temporary trusted test contexts but should not be used for broad real-world automation.
+
+- Security page: [user-guide/security/](https://hermes-agent.nousresearch.com/docs/user-guide/security/)
+
+### 3.3 Secrets management (verified)
+
+- Hermes documents runtime secret ingestion via external managers:
+  - Bitwarden Secrets Manager (`bws`)
+  - 1Password (`op://` references via `op` CLI)
+- Secrets sources can be composed and precedence is documented; bootstrapping token behavior is documented, and tool outputs include redaction controls.
+
+- Secrets page: [user-guide/secrets/](https://hermes-agent.nousresearch.com/docs/user-guide/secrets/)
+
+### 3.4 MCP and tool expansion (verified)
+
+- Hermes supports local stdio MCP servers and remote HTTP MCP servers.
+- MCP catalog entries are installed intentionally; configuration uses explicit checks, and the docs call out manifest-level review.
+- MCP is **not** auto-updated; updates require reinstall/reconfiguration after Hermes upgrades.
+- Tool exposure is filterable via include/exclude controls.
+
+- MCP docs: [user-guide/features/mcp/](https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp/)
+- MCP config reference: [reference/mcp-config-reference/](https://hermes-agent.nousresearch.com/docs/reference/mcp-config-reference/)
+
+### 3.5 Messaging and gateway boundaries (verified)
+
+- Hermes supports multiple messaging channels and uses different platform capabilities.
+- Gateway command support and per-platform behaviors are documented.
+- Group/chat surfaces should be intentionally bounded because incoming messages are command entry points.
+
+- Messaging docs: [user-guide/messaging/](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/)
+
+### 3.6 Provider routing and latest release (verified)
+
+- Hermes providers page confirms direct cloud endpoints, self-hosted providers, and local/custom providers.
+- `config` docs define resolution order and explicit config location, useful for separating secrets from non-secret runtime settings.
+
+- Providers: [integrations/providers/](https://hermes-agent.nousresearch.com/docs/integrations/providers/)
+- Config: [user-guide/configuration/](https://hermes-agent.nousresearch.com/docs/user-guide/configuration/)
+
+- Latest tagged release observed via GitHub releases: **v2026.7.7.2** (Hermes Agent v0.18.2), released 2026-07-08.
+- GitHub release feed: https://github.com/NousResearch/hermes-agent/releases
+
+---
+
+## 4) Trust boundary by workflow (scanable use-case catalog)
+
+Use this as a planning table before enabling any integration.
+
+| Use case | Suggested boundary | Identity pattern | Required controls | Human gate | Why this boundary |
+| --- | --- | --- | --- | --- | --- |
+| Information lookup, summarization, ranking, stats prep | **Zone 1 (Read-only)** | Dedicated bot/helper profile; source account with read-only scope | Separate API keys by task; read-only toolset (`web`, limited `file` read, `read_terminal`) | No | Read tasks are high-value and low-risk when writes are blocked |
+| Drafting only (email drafts, PR drafts, notes, meeting summaries) | **Zone 2 (Draft output, no send/publish)** | Agent-owned helper account or sandbox mailbox | Draft-only folders, no send scope, no public-post credentials | Before send/publish | Lets Hermes move work forward while keeping irreversible actions explicit |
+| Coding + PR prep | **Zone 2 → Zone 3 as needed** | Dedicated code agent identity; repo write limited to project branches/repo path | Scoped toolset (`terminal`, `file`, safe MCP subset), branch-based write rules | PR close / merge actions | Useful for productivity, still prevents accidental blast radius |
+| GitHub moderation workflows | **Zone 3 (Agent-owned identity)** | Helper account with minimal org/app scopes | MCP filtering, allowlist, action logging, `/who` identity checks | Removals and public moderation actions | Keeps human brand/work identity separate from agent-run workflows |
+| Messaging assistants (Telegram/Discord/Slack) | **Zone 3 + Zone 4 for active ops** | Bot tokens and per-channel allowlist | Messaging gateway allowlist, channel permissions, no broad DM trust | External sends and sensitive attachments | Gateway surfaces are command interfaces; default to minimal send scope |
+| Workplace support queries (sanitized data) | **Zone 3/4 depending on data class** | Separate approved tenant account or sandbox integration | HR/IT-reviewed app scope, redaction policies, session timeout controls | Any production action or outbound update | Compliance-first design avoids unauthorized workflow drift |
+| Finance-like workflow prep (statements, reporting) | **Zone 2 only** for prep; **Zone 5 for action** | Separate account with non-payment scope + staging area | No payment scopes in active agent profile; checkpoints and audit log | Payroll submit, transfers, tax/submission | Prevents irreversible value movement without explicit human command |
+
+**Zone shorthand used below**
+
+- **Zone 1** = read-only access only
+- **Zone 2** = draft/prep access, no final irreversible action
+- **Zone 3** = dedicated agent-owned identity
+- **Zone 4** = high-trust delegated access with strong controls
+- **Zone 5** = never-autonomous (human final click required)
+
+---
+
+## 5) Practical integration recipes
+
+### 5.1 Mail, calendar, docs, and drive
+
+- Use OAuth where possible and keep scopes minimal.
+- Prefer dedicated Hermes mail/helper identity where feasible.
+- Keep send/delete/re-share actions in human approval.
+- Share only specific folders/scope, not full account access.
+
+### 5.2 MCP servers and plugin surfaces
+
+- Install only needed MCP entries.
+- Read the manifest and source repo before install.
+- Use `include`/`exclude` filtering at config level to reduce tool blast radius.
+- Reconfigure tool selection after MCP server/provider changes.
+
+### 5.3 Messaging gateways
+
+- Use allowlists when possible; keep channel permissions small.
+- Treat DM-to-tool paths as untrusted unless explicitly paired.
+- Keep final send for sensitive messages in human-approved mode.
+
+### 5.4 Payments, payroll, HR, legal, and medical actions
+
+- Keep these outside the autonomous model loop by default.
+- Restrict APIs to read/prep if possible and enforce final human execution for commit actions.
+
+---
+
+## 6) Comment-sourced updates (durable, included)
+
+| Date (UTC) | Author | Type | Update added to guide | Why | Source |
+| --- | --- | --- | --- | --- | --- |
+| 2026-07-11 | /u/Dry_Relationship_388 | Addition | Use Hermes for query/statistics/knowledge capture and keep manual gates on broader actions | Reinforces practical role segmentation and limited delegation | [comment](https://www.reddit.com/r/hermesagent/comments/1usz3d3/agent_trust_boundary_megathread_connect_the_tools/owwfs13/) |
+| 2026-07-11 | /u/WatercressBudget9418 | Correction | Human gate is required on all actions that spend money, leave the system, or publish | Clarifies that trust risk includes successful-but-unperformed actions by the model | [comment](https://www.reddit.com/r/hermesagent/comments/1usz3d3/agent_trust_boundary_megathread_connect_the_tools/owtn94o/) |
+| 2026-07-11 | /u/Jonathan_Rivera | Addition | Local-first workflows can be paired with cloud fallback; explicit workflow chunking remains important | Adds implementation preference while preserving verification-first operation style | [comment](https://www.reddit.com/r/hermesagent/comments/1usz3d3/agent_trust_boundary_megathread_connect_the_tools/owtr7ba/) |
+| 2026-07-11 | /u/rittatewa | Needs-verification | Scoped agent/runtime credentials can reduce blast radius of shared provider keys; external `NyxID` design shared | Valuable security architecture pattern but external implementation details are not in official docs and need separate validation | [comment](https://www.reddit.com/r/hermesagent/comments/1usz3d3/agent_trust_boundary_megathread_connect_the_tools/owyf2ej/) |
+
+---
+
+## 7) Unresolved community claims (archive, not treated as verified facts)
+
+These are kept for traceability and should not be represented as canonical requirements without external verification.
+
+| Date (UTC) | Claim type | Origin | Claim | Reason for archive | Required follow-up |
+| --- | --- | --- | --- | --- | --- |
+| 2026-07-11 | Subjective / single-user workflow | /u/Jonathan_Rivera | Local-first on Mac with cloud redundancy is the preferred personal setup | Personal operating preference, not a universal rule | None; retain only as an operator preference |
+
+No pricing, benchmark, promotion, availability, or reputational claims in this source set rise to canonical status.
+
+---
+
+## 8) Preflight checklist (use before connecting anything new)
+
+- Is there an explicit business reason for this integration?
+- Can most actions start in read-only mode?
+- Does this account carry irreversible actions (money, deletes, publishes, user/permission changes)?
+- Are credentials stored in a manager or vault, with bootstrap secrets rotated?
+- Is this a dedicated agent identity (not a shared personal credential)?
+- Are MCP tools filtered to least privilege?
+- Are approval modes set to a safe default (`manual` or `smart`)?
+- Is a hardline or custom deny policy in place?
+- Is there a documented revoke path (platform + model provider + gateway credential)?
+- Is this workplace-approved and compliance-aligned?
+
+---
+
+## 9) FAQ (compact)
+
+**Should Hermes get my main account credentials?**
+
+Not by default. Start with dedicated identities and the minimum possible scopes.
+
+**Is manual approval always required?**
+
+Not for every command. Use `manual`/`smart` by default; reserve `off/yolo` for isolated test contexts with explicit intent.
+
+**Can Hermes use toolsets safely with local-only deployment?**
+
+Local models reduce one risk class, but tool and account permission risk still applies. Boundaries are about permissions, not just model locality.
+
+**What is the biggest practical failure mode?**
+
+False confidence and unchecked irreversible paths, not only malicious behavior.
+
+---
+
+## 10) Source index (traceability)
+
+### Official documentation
+- [Security](https://hermes-agent.nousresearch.com/docs/user-guide/security/)
+- [Secrets](https://hermes-agent.nousresearch.com/docs/user-guide/secrets/)
+- [MCP](https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp/)
+- [MCP config reference](https://hermes-agent.nousresearch.com/docs/reference/mcp-config-reference/)
+- [Messaging gateway](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/)
+- [Provider routing](https://hermes-agent.nousresearch.com/docs/integrations/providers/)
+- [Configuration](https://hermes-agent.nousresearch.com/docs/user-guide/configuration/)
+- [Tools reference](https://hermes-agent.nousresearch.com/docs/reference/tools-reference/)
+- [GitHub releases](https://github.com/NousResearch/hermes-agent/releases)
+
+### Reddit source
+- Original post: https://www.reddit.com/r/hermesagent/comments/1usz3d3/agent_trust_boundary_megathread_connect_the_tools/
+- Source dataset: repository import snapshot used for migration

--- a/megathreads/cost-token-optimization-2026-06.md
+++ b/megathreads/cost-token-optimization-2026-06.md
@@ -1,0 +1,400 @@
+# Cost & Token Optimization Megathread — Hermes Agent (June 2026)
+
+> Community-maintained GitHub version of the Reddit megathread.
+>
+> Original Reddit thread: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/
+>
+> **Snapshot:** Original post preserved and normalized; comment corrections reviewed through July 16, 2026.
+>
+> Time-sensitive prices, quotas, versions, model availability, benchmarks, and third-party project claims remain dated snapshots unless an official source is cited.
+
+---
+
+**LAST UPDATED:** June 21, 2026
+**Sourced from:** r/hermesagent cost threads, official Hermes context compression/caching docs, provider pricing pages (DeepSeek, Anthropic, OpenAI), GitHub issue #4379 (token overhead analysis).
+
+---
+
+## TL;DR — What's This Going to Cost Me?
+
+| Decision | Cheapest Option | Monthly Est. | Runner-Up | Monthly Est. |
+|----------|----------------|-------------|-----------|-------------|
+| **API model** | DeepSeek V4 Flash | $3-10/mo | DeepSeek V4 Pro (75% off) | $8-20/mo |
+| **Local model** | Qwen 3.6-27B on RTX 3090 | $0/mo (electricity only) | Qwen 3.5-9B on any GPU | $0/mo |
+| **VPS + API** | Oracle free tier + Flash | $3-10/mo | Hetzner €4 + Flash | $7-14/mo |
+| **All-in (VPS + API + tools)** | ~$15-25/mo | Real community budget | ~$30-35/mo | u/Background-Remote765 |
+| **Token overhead** | ~73% of each call is fixed | Use toolset trimming | ~40% after trimming | hermes-token-router |
+
+---
+
+## Part 1: Provider Pricing — Historical June 2026 Snapshot
+
+> **Do not use these figures as a live price sheet.** The rows below preserve what the Reddit post reported in June 2026 and were not independently reverified line by line during the July 2026 migration. Before purchasing or routing production traffic, check the provider's official pricing, quota, cache, context, and regional-policy pages. Community monthly-cost and hardware break-even figures are examples, not guarantees.
+
+### 🥇 DeepSeek (Best Value)
+
+| Model | Input / 1M tokens | Output / 1M tokens | Context | Notes |
+|-------|-------------------|-------------------|---------|-------|
+| **V4 Flash** | **$0.14** | **$0.28** | 1M | 18× cheaper than GPT-5.4 input. Cached: $0.014/M. |
+| **V4 Pro** | $1.74 ($0.435*) | $3.48 ($0.87*) | 1M | *75% off promotional pricing. Strongest reasoning. |
+| **V3.2** | $0.27 | $1.10 | 128K | Legacy but still viable. |
+| **R1** | $0.55 | $2.19 | 128K | Reasoning model. |
+
+**Community consensus:** V4 Flash for everyday agent work. V4 Pro for complex reasoning. The 75% off Pro pricing makes it competitive with Flash for heavy reasoning tasks.
+
+**Direct API vs OpenRouter:** Always use DeepSeek's direct API. OpenRouter adds a markup. No benefit for single-provider use.
+
+### 🥈 Anthropic Claude (Best Quality, Higher Cost)
+
+| Model | Input / 1M | Output / 1M | Context | Cached Input / 1M |
+|-------|-----------|------------|---------|-------------------|
+| **Sonnet 4** | $3.00 | $15.00 | 200K | $0.30 |
+| **Sonnet 4.6** | $3.00 | $15.00 | 200K | $0.30 |
+| **Opus 4.7** | $15.00 | $75.00 | 200K | $1.50 |
+
+**Prompt caching is critical with Claude:** Hermes automatically caches the system prompt + rolling 3-message window. Cache hits cost **90% less** on input tokens. In practice, multi-turn conversations with Claude can see 50-70% effective input cost reduction.
+
+**When Claude is worth it:** Complex multi-step coding, security-sensitive work, tasks where tool-calling reliability is paramount. "The boring model that follows schema for 6+ tool calls beats the spicy one that talks itself into a ditch."
+
+### 🥉 OpenAI (Wide Ecosystem)
+
+| Model | Input / 1M | Output / 1M | Context |
+|-------|-----------|------------|---------|
+| GPT-5.4 | $2.50 | $10.00 | 128K |
+| GPT-5.5 | $5.00 | $20.00 | 272K (Codex) / 1.05M (direct) |
+| GPT-4o | $2.50 | $10.00 | 128K |
+
+### Local Models (Zero API Cost)
+
+| Setup | Hardware Cost | Running Cost | Real-World Tok/s |
+|-------|-------------|-------------|-----------------|
+| Qwen 3.6-27B Q4 | RTX 3090 ($700 used) | ~$15/mo electricity | 25-40 tok/s |
+| Qwen 3.5-9B | RTX 3060 ($200 used) | ~$5/mo electricity | 40-60 tok/s |
+| Qwen 3.6-35B-A3B | M1 Max 64GB | Laptop you own | 61 tok/s (MLX) |
+| DeepSeek V4-Flash local | 2× RTX 5090 | ~$30/mo electricity | Production speed |
+
+**When local breaks even:** If you spend >$20/mo on API tokens, a used RTX 3090 pays for itself in ~35 months on electricity alone. Add VPS savings (no VPS needed) and it's faster.
+
+### Free Tier Options — Historical Snapshot
+
+Availability and limits in this table can change without notice. Verify each provider's current official free-tier page before relying on it.
+
+| Provider | What You Get | Limits | Community Verdict |
+|----------|-------------|--------|-------------------|
+| OpenRouter free models | Multiple models, no credit card | Rate limited, inconsistent tool calling | Test/fallback only |
+| Nous Portal free tier | Bundled Hermes models | Limited context | Solid for light use |
+| DeepSeek | $5 free credit (new accounts) | One-time | Good starter |
+| Google Gemini | Free tier available | Rate limits, 503 errors | "Nearly destroyed my entire hermes" — u/Simple_Tune2882. Multiple users report 503s even on paid tier. |
+| Opencode Go | $10/mo → **$60 in API credits** | 6x credit multiplier; Kimi 2.6, Mimo, etc. | **Top recommendation.** "I've been using Kimi 2.6 pretty hard and in 5 days only managed to use 11% of my monthly allowance." |
+| Minimax | $10/mo plan | Minimax 2.7, M3 ("as good as GPT 5.5-low") | "Most overlooked model" — multiple users |
+| NanoGPT | $8/mo | 60M tokens/week with GLM 5.1 | Extremely cheap if GLM works for you |
+| Ollama Cloud | $20/mo flat | No usage caps | "Not even getting close to hitting the limits"; some speed complaints |
+
+### Plan vs API: The Decision Framework
+
+From u/getstackfax — the clearest framework on the subreddit:
+
+**Use a plan when:**
+- You're doing heavy daily interactive use
+- You want predictable billing (no $54 surprises)
+- The plan covers models you actually use
+- You're not disciplined enough to audit your API usage weekly
+
+**Use raw API when:**
+- You route carefully between cheap models
+- You keep context small and caching tight
+- You've set budget caps and loop guards
+- You actually check your provider dashboard weekly
+
+**The golden rule:** *"API is dangerous if the agent is allowed to wander."* Plans cap your downside. API requires discipline.
+
+**The dashboard audit checklist** (weekly):
+- Model actually used vs default
+- Cache hit rate (not just "caching supported" — verify hits)
+- Input/output token split
+- Fallback/ escalation events
+- Background/heartbeat costs
+- Total cost per useful task
+
+> *"'Caching supported' and 'your workflow is actually getting cache hits' are different things."* — u/getstackfax
+
+---
+
+## Part 2: The Token Overhead Problem
+
+**73% of every Hermes API call is fixed overhead that doesn't change between requests.**
+
+From GitHub issue #4379 — community analysis of 6 request dumps from a Telegram + WhatsApp + Cron deployment:
+
+- System prompt: ~3,000-8,000 tokens
+- Tool definitions: ~2,000-15,000 tokens (depends on enabled toolsets)
+- Memory injection: variable (grows over time)
+- SOUL.md / USER.md: ~500-2,000 tokens
+- **Actual conversation:** only ~27% of the call
+
+### Where Your Tokens Actually Go
+
+| Component | Approximate Tokens | Variable? | Can You Trim It? |
+|-----------|-------------------|-----------|-----------------|
+| System prompt | 3,000-8,000 | Somewhat | No — core functionality |
+| Tool definitions | 2,000-15,000 | **Yes** | **Yes — disable unused toolsets** |
+| Memory | 500-5,000+ | Yes, grows | Yes — trim old memories |
+| SOUL.md | 200-2,000 | Yes | Yes — keep it compact |
+| USER.md | 200-1,500 | Yes | Yes — keep it compact |
+| Skills context | 200-3,000 | Yes | Yes — fewer loaded skills |
+| Conversation history | 1,000-50,000+ | Yes, grows | Compression handles this |
+
+### How to Cut Overhead by 40-50%
+
+**1. Toolset trimming (biggest win):**
+```bash
+# See what's enabled
+hermes tools
+
+# Disable toolsets you never use
+hermes config set toolsets.enabled "['terminal','file','web','skills']"
+# NOT: "['terminal','file','web','skills','browser','computer_use','vision','image_gen','tts','discord','spotify','homeassistant','kanban','todo','cronjob','delegation']"
+```
+
+Every disabled toolset removes its entire JSON schema from every API call. The `browser` toolset alone can add 1,500+ tokens.
+
+**2. Compact SOUL.md and USER.md:**
+- Target 500-1,000 tokens each
+- Remove examples, verbose instructions
+- Use bullet points, not paragraphs
+- Test: does the agent still behave correctly? If yes, you haven't lost anything.
+
+**3. Memory hygiene:**
+- Run `hermes memory stats` to see memory size
+- Remove stale/duplicate memories
+- Memory grows with every session — prune periodically
+
+**4. Use the hermes-tool-router plugin (in development):**
+Predicts which toolsets are needed before each turn and only sends those definitions. Can cut tool overhead by 60-80% per turn. Currently in testing.
+
+---
+
+## Part 3: Context Compression — How Hermes Saves Tokens
+
+Hermes has a dual compression system that fires automatically:
+
+### Layer 1: Agent Compressor (50% threshold)
+Fires when prompt tokens reach 50% of the model's context window:
+1. Prunes old tool results (>200 chars are replaced with a placeholder)
+2. Summarizes middle conversation turns into a structured summary
+3. Preserves last N messages (tail) unmodified
+4. On subsequent compressions, **updates** the existing summary instead of re-summarizing
+
+### Layer 2: Gateway Session Hygiene (85% threshold)
+Safety net for long-running gateway sessions (Telegram/Discord). Catches sessions that escaped the agent's own compressor.
+
+### Tuning Compression
+
+```yaml
+compression:
+  enabled: true
+  threshold: 0.50          # Fire at 50% of context (default)
+  target_ratio: 0.20       # Tail gets 20% of threshold budget
+  protect_last_n: 20       # Minimum tail messages preserved
+```
+
+**Lower threshold = more aggressive compression = lower costs but more context loss.** Default 0.50 is well-tuned. Don't go below 0.30 — you'll lose too much context.
+
+### The Summary Model Matters
+
+The summary is generated by a separate LLM call. If the summary model's context window is **smaller** than the main model's, compression fails silently and you **lose conversation context with no warning.** Always ensure your auxiliary/compression model has at least as large a context window as your main model.
+
+---
+
+## Part 4: Prompt Caching — Anthropic's 90% Discount
+
+When using Claude models, Hermes automatically uses Anthropic's prompt caching:
+
+- **System prompt** — cached across all turns (breakpoint 1)
+- **Last 3 messages** — rolling cache window (breakpoints 2-4)
+- **Cache hit savings:** 90% reduction on input tokens
+- **Real-world impact:** 50-70% effective input cost reduction in multi-turn conversations
+
+**Cache-aware tips:**
+- Don't modify SOUL.md mid-conversation — it invalidates the system prompt cache
+- The rolling 3-message window re-establishes within 1-2 turns after compression
+- TTL configurable: `prompt_caching.cache_ttl: "5m"` (default) or `"1h"` for slow conversations
+
+```yaml
+prompt_caching:
+  cache_ttl: "1h"    # Better for Telegram where turns have gaps
+```
+
+---
+
+## Part 5: Community Cost-Saving Strategies
+
+### Strategy 1: Cheap Model for Easy Tasks, Expensive for Hard
+
+The "router" pattern — most-recommended across all cost threads:
+```yaml
+# config.yaml — main model
+model:
+  default: deepseek/deepseek-v4-flash
+
+# For complex tasks, switch mid-session:
+/model anthropic/claude-sonnet-4
+```
+
+Use DeepSeek Flash for 80% of agent work. Switch to Claude only when tool-calling reliability matters or you hit a task Flash can't handle.
+
+**Community consensus on model tiers for agent work:**
+- 🥇 **Daily driver:** DeepSeek V4 Flash, Minimax 2.7, Qwen 3.6-27B (local)
+- 🥈 **Complex reasoning:** DeepSeek V4 Pro, Claude Sonnet 4, Kimi K2.6
+- 🥉 **Budget/light:** GLM 4.7 Flash, Gemma 4 26B, Granite 4.1 8B
+- ⚠️ **Avoid for Hermes:** Gemma 4 ("bugged with Hermes — tool call issues" confirmed by multiple users), Gemini (503 errors, "nearly destroyed my entire hermes")
+
+### Strategy 2: Local Inference + Cloud Fallback
+
+Run a local model (Qwen, Llama) as primary. Fall back to DeepSeek API when the local model struggles:
+```yaml
+providers:
+  custom:
+    local-qwen:
+      base_url: http://localhost:1234/v1
+      api_key: not-needed
+      models: [qwen3.6-27b]
+
+model:
+  default: custom:local-qwen/qwen3.6-27b
+  fallback: deepseek/deepseek-v4-flash
+```
+
+### Strategy 3: Subagent Delegation for Cost Isolation
+
+Delegate expensive reasoning to short-lived subagents that use cheaper models:
+- Parent agent uses DeepSeek Flash (cheap)
+- Research subagent uses DeepSeek Flash (cheap, isolated context)
+- Only the summary comes back — no token history contamination
+
+### Strategy 4: API Direct, Not OpenRouter
+
+OpenRouter adds markup. If you use primarily one provider:
+- DeepSeek: use direct `deepseek` provider
+- Anthropic: use direct `anthropic` provider
+- OpenAI Codex: use direct `openai-codex` provider
+
+Only use OpenRouter if you genuinely need multi-provider routing.
+
+### Strategy 5: Disable Browser Automation
+
+Browser tools are the single biggest token and cost sink:
+- Each browser action = screenshots processed by vision models = thousands of tokens
+- Use APIs instead: Exa for search, Himalaya for email, CLI tools for everything
+- "Agents speak and read text way better than puppeting a browser and screenshotting" — u/Starrwulfe
+
+### Strategy 6: cronjob Timing
+
+Don't run heavy processing during peak hours. Schedule daily briefs, research, and maintenance tasks for off-peak when you're not actively chatting:
+```bash
+cronjob create --schedule "0 3 * * *" --prompt "Generate daily brief from yesterday's activity"
+```
+
+---
+
+## Part 6: Real Community Budgets
+
+### Budget Build (~$15-25/month)
+- Oracle Cloud free tier VPS (or Hetzner €4)
+- DeepSeek V4 Flash API: $5-15/month
+- No browser tools
+- Toolset trimming enabled
+- Compression at 50% default
+
+### Mid-Range (~$30-35/month) — u/Background-Remote765's actual setup
+- Netcup VPS: $10-13/month
+- Hetzner Storage Share: $4/month
+- DeepSeek API: $5-10/month
+- Tailscale: Free
+- **Replaces:** Spotify, Google ecosystem, AI subscriptions, streaming services
+
+### Local-First (~$5-15/month electricity)
+- Used RTX 3090 ($700 one-time)
+- Qwen 3.6-27B local inference
+- DeepSeek Flash as fallback only
+- No VPS needed
+- Breaks even vs $30/mo cloud in ~2 years
+
+---
+
+## Part 7: FAQ
+
+**Q: What's the absolute cheapest way to run Hermes?**
+A: Local inference on hardware you already own. Qwen 3.5-9B runs on any GPU with 8GB+ VRAM. Zero API cost. Second cheapest: DeepSeek V4 Flash at $0.14/M input — most users spend $3-10/month.
+
+**Q: Why am I burning through $20+/month on DeepSeek?**
+A: Check your enabled toolsets. A full toolset load adds 10,000-15,000 tokens to every API call — even for "hello." Disable unused toolsets, trim SOUL.md, and check compression is enabled.
+
+**Q: Is Claude worth 20× the price of DeepSeek Flash?**
+A: For everyday agent work, no. For complex multi-step coding, security audits, or tasks where tool-calling errors cascade — yes. Use Flash as default, switch to Claude when needed.
+
+**Q: Does prompt caching work with non-Anthropic models?**
+A: No. Prompt caching is Anthropic-specific. DeepSeek has its own caching ($0.014/M cached input — 90% off). OpenAI doesn't offer comparable caching for the API tier.
+
+**Q: How do I know how much I'm spending?**
+A: Check your provider's dashboard. DeepSeek shows usage in real-time. For Anthropic/OpenAI, check the billing console. Hermes logs token counts per turn in session files.
+
+**Q: Should I use OpenRouter to save money?**
+A: Generally no. OpenRouter adds markup. Direct provider APIs are cheaper for single-provider use. OpenRouter's value is multi-provider access and fallback routing — not cost savings.
+
+**Q: Will local models actually work for agentic tasks?**
+A: Yes. Qwen 3.6-27B handles tool calling reliably for most tasks. Uncensored variants (Heretic, HauhauCS) may be better at creative problem-solving but can be less reliable at schema-following. Test before relying on them.
+
+**Q: What's eating my tokens when I'm not even chatting?**
+A: Gateway sessions accumulate context. Overnight, a Telegram thread can grow to thousands of tokens just from idle system checks. The gateway session hygiene compressor (85% threshold) handles this. Make sure compression is enabled.
+
+**Q: Can I set a hard budget limit?**
+A: Set budget alerts on your provider's dashboard. Hermes doesn't have built-in budget caps yet. Most providers let you set spending limits or hard caps.
+
+---
+
+## Part 8: Provider Comparison — June 2026
+
+| Provider | Model | Input $/M | Output $/M | Context | Cached Input | Best For |
+|----------|-------|----------|-----------|---------|-------------|----------|
+| DeepSeek | V4 Flash | $0.14 | $0.28 | 1M | $0.014 | Default agent work |
+| DeepSeek | V4 Pro* | $0.435 | $0.87 | 1M | $0.044 | Complex reasoning |
+| Anthropic | Sonnet 4 | $3.00 | $15.00 | 200K | $0.30 | Reliable tool calling |
+| Anthropic | Opus 4.7 | $15.00 | $75.00 | 200K | $1.50 | Critical/security work |
+| OpenAI | GPT-5.4 | $2.50 | $10.00 | 128K | — | Ecosystem integration |
+| OpenAI | GPT-5.5 | $5.00 | $20.00 | 272K-1.05M | — | Max context tasks |
+| Local | Qwen 3.6-27B | $0 | $0 | ~64K | $0 | Privacy, zero API cost |
+| Local | Qwen 3.5-9B | $0 | $0 | ~32K | $0 | Low-VRAM setups |
+
+*\*DeepSeek V4 Pro 75% promotional discount — subject to change*
+
+---
+
+## Part 9: The Bottom Line
+
+Hermes is as expensive as you let it be. The defaults are generous — full toolsets, verbose system prompts, growing memory. Trimming these to what you actually use cuts costs by 40-50% with zero quality loss.
+
+**The three highest-impact moves:**
+1. Switch to DeepSeek V4 Flash if you're on Claude/OpenAI for everyday work (10-50× cheaper)
+2. Disable unused toolsets (saves 2,000-10,000 tokens per call)
+3. Make sure compression is enabled (saves context from growing unbounded)
+
+A well-tuned Hermes on DeepSeek Flash costs $3-15/month for active daily use. Add a VPS and you're at $15-30/month all-in. That's less than a ChatGPT Plus subscription and infinitely more capable.
+
+---
+
+**Sourced from:** r/hermesagent cost threads (65+ comments across 3 dedicated threads), official Hermes compression/caching documentation, provider pricing pages (June 2026), GitHub issue #4379 token overhead analysis, and community-reported monthly budgets.
+
+---
+
+## Comment-Sourced Updates
+
+- **Price claims are snapshots:** discounts, free tiers, and “permanent” prices can change. Recheck the provider page before using any monthly estimate.
+
+- **Measure the full route:** model price alone does not capture cache behavior, reliability, retries, tool payloads, data region, or aggregator markup.
+
+- **Repeatable first controls:** disable unused toolsets, constrain browser/extraction output, reduce unnecessary schemas, and compare token payloads before and after each change. Community percentage savings are not universal benchmarks.
+
+## Maintaining this guide
+
+Open an issue or pull request with the official source, date checked, Hermes/backend version, and enough reproduction detail to evaluate the change. No referral links, affiliate links, or unsupported promotional claims.

--- a/megathreads/free-models-apis-2026-06.md
+++ b/megathreads/free-models-apis-2026-06.md
@@ -1,13 +1,13 @@
-# Free Models and APIs for Hermes Agent — Megathread (June 2026)
+# Free Models and APIs for Hermes Agent — Historical June 2026 Snapshot
 
 > Community-maintained GitHub version of the Reddit megathread.
 >
 > Original Reddit thread: https://www.reddit.com/r/hermesagent/comments/1uj9nkn/free_models_apis_for_hermes_agent_megathread_june/
 >
-> This file preserves the original megathread content and adds comment-sourced updates where users clarified practical usage, GitHub maintenance, and contribution workflow.
+> This file preserves the June 2026 megathread as a historical snapshot and adds comment-sourced corrections. **It is not a current availability or pricing list.** Free model IDs, quotas, and routes change quickly; verify the provider's live API/catalog immediately before configuration.
 
 
-**LAST UPDATED: June 29, 2026**\
+**LAST UPDATED: July 16, 2026**\
 **Scope:** Free models available via OpenRouter and other free API
 sources — what's available, what the community uses, and what works for
 different use cases.\
@@ -16,7 +16,9 @@ OpenRouter model listings/category rankings, API provider documentation.
 
 ------------------------------------------------------------------------
 
-## Part 1: TL;DR — Quick Picks
+## Part 1: Historical June 2026 Quick Picks
+
+> **Current-status correction (July 16, 2026):** These are the original post's picks, not current recommendations. A live OpenRouter catalog check performed during release review did not show the former `:free` IDs for DeepSeek V4 Flash, gpt-oss-120b, LFM2.5 thinking/instruct, or Owl Alpha. Owl Alpha's page still resolved but its API-catalog status was ambiguous. Laguna XS.2 appeared superseded by a newer release. Treat every row below as historical until its exact model ID is confirmed in the provider's current API catalog.
 
 | Decision | Community Pick | Runner-Up |
 |----|----|----|
@@ -35,9 +37,10 @@ work as paid flagships. For unattended/agentic tasks, users report
 needing detailed step-by-step instructions often drafted by a better
 model (e.g., Claude, GPT 5.5).
 
-All 26 free models at:
+At the original June 2026 capture, the post reported 26 free models at:
 <https://openrouter.ai/models?max_price=0&input_modalities=text&supported_parameters=tools>
-(18 text→text with tools; 26 total across all modalities).
+
+That count is not durable. Use the live filtered catalog rather than the historical number.
 
 ------------------------------------------------------------------------
 
@@ -67,7 +70,7 @@ Solid performers with good community feedback.
 | **[Llama 3.3 70B](https://openrouter.ai/meta-llama/llama-3.3-70b-instruct:free)** (Meta) | 70B dense | 131K | — | Multilingual dialogue, broad benchmarks |
 | **[Qwen3 Next 80B A3B](https://openrouter.ai/qwen/qwen3-next-80b-a3b-instruct:free)** (Qwen) | 3B / 80B | 256K | — | RAG, tool use, agentic workflows, no thinking traces |
 | **[Nemotron 3 Ultra](https://openrouter.ai/nvidia/nemotron-3-ultra-550b-a55b:free)** (NVIDIA) | 55B / 550B | 1M | Finance \#32 | Frontier reasoning, orchestration, coding agents |
-| **DeepSeek V4 Flash** | — | — | — | Community favorite for speed; mixed reliability reports |
+| **DeepSeek V4 Flash (historical route)** | — | — | — | Former community speed pick; the prior OpenRouter free ID was not present in the live API catalog during the July 16 review. Verify direct/aggregator pricing and availability. |
 
 ------------------------------------------------------------------------
 
@@ -78,7 +81,7 @@ Focused models for specific tasks.
 | Model | Active Params | Context | Best For |
 |----|----|----|----|
 | **[Qwen3 Coder 480B](https://openrouter.ai/qwen/qwen3-coder:free)** (Qwen) | 35B / 480B | 1.05M | Agentic coding, function calling, repo-level reasoning |
-| **[Laguna XS.2](https://openrouter.ai/poolside/laguna-xs.2:free)** (Poolside) | — | 256K | Efficient coding agent, compact footprint |
+| **Laguna XS.2 (legacy June entry)** | — | 256K | Efficient coding agent in the original snapshot; verify the current successor/model ID before use |
 | **[Nemotron 3 Nano 30B](https://openrouter.ai/nvidia/nemotron-3-nano-30b-a3b:free)** (NVIDIA) | 3B / 30B | 256K | Specialized agentic AI, customization |
 | **[Nemotron 3 Nano Omni](https://openrouter.ai/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free)** (NVIDIA) | 3B / 30B | 256K | Multimodal perception sub-agent — text, image, video, audio |
 | **[gpt-oss-20b](https://openrouter.ai/openai/gpt-oss-20b:free)** (OpenAI) | 3.6B / 21B | 131K | Consumer/GPU hardware, function calling, structured outputs |
@@ -380,6 +383,15 @@ living resource — new free models appear regularly and rankings shift.
 ---
 
 ## Comment-Sourced Updates Added From Reddit
+
+
+### July 16 status and reliability corrections
+
+- **Free does not mean durable.** Commenters reported trial keys exhausting within minutes and models disappearing from free routes. Check the live provider/model page immediately before configuring a production route.
+- **OpenRouter and direct-provider behavior can differ.** Latency, caching, quota, and model availability reported through an aggregator do not necessarily describe the direct API.
+- **DeepSeek and Owl Alpha status changed during the thread.** Their entries below are historical snapshots, not guarantees of current free availability.
+- **NVIDIA-hosted Nemotron quotas were reported as limited.** Verify the current NVIDIA NIM quota before depending on it.
+- **Unverified additions stay in the comment archive.** SiliconFlow, OpenCode, GonkaRouter, Requesty, Stepfun, and individual Google AI Studio error reports are not promoted to canonical recommendations without current official confirmation.
 
 These notes came from the discussion under the original Reddit post. They are included here so the GitHub version reflects the thread, not just the original post.
 

--- a/megathreads/hermes-agent-use-cases-2026-07.md
+++ b/megathreads/hermes-agent-use-cases-2026-07.md
@@ -1,0 +1,374 @@
+# MEGATHREAD: Hermes Agent Use Cases — What the Community is Building (May 2026)
+
+> Community-maintained GitHub version of the Reddit megathread.
+>
+> Original Reddit thread: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/
+>
+> **Snapshot:** Original post preserved and normalized; comment corrections reviewed through July 16, 2026.
+>
+> Time-sensitive prices, quotas, versions, model availability, benchmarks, and third-party project claims remain dated snapshots unless an official source is cited.
+
+---
+
+Part 1 - Part two in a sticky post below.
+
+A community-sourced compilation of real-world Hermes Agent use cases, pulled from Reddit, X/Twitter, GitHub (issues, PRs, community repos), YouTube, Hacker News, blogs, podcasts, LinkedIn, Product Hunt, and GitHub Gists.
+
+**240 source rows retained across 11 categories in this repository snapshot.** The original Reddit post described a larger 276-use-case/16-category corpus; not all entries were present in the captured post body. This file reports only what is actually preserved below.
+
+> **Source-label caveat:** Rows that say only `GitHub`, `GitHub Gist`, `X`, `Blog`, `Reddit`, `LinkedIn`, `Product Hunt`, `Hacker News`, or `Podcast` did not preserve a direct URL in the captured post. Treat those as unverified leads, not sourced claims.
+
+---
+
+## Dev Workflow (64 retained rows)
+
+People using Hermes for software development, codebase analysis, CI/CD, multi-agent build pipelines, and developer tooling.
+
+| Use Case | Source |
+|----------|--------|
+| 12 Hermes instances every day, in parallel — backend team monitors stack, post-training team creates RL environments and benchmarks | [@Teknium on X](https://x.com/Teknium) |
+| Multi-agent auto-build workflow (plan to code to QA to ship) — GPT-5.4 orchestrates, MiniMax M2.7 codes, local Qwen 35B tests | [@gkisokay on X](https://x.com/gkisokay) |
+| Hermes as a watchdog for OpenClaw — saved hours every day | [@gkisokay on X](https://x.com/gkisokay) |
+| Day 10: agent knows my codebase better than I do | X |
+| Built my own stack, then converged on Hermes | X |
+| Agent sees a file change and auto-acts on it | X |
+| Codex watches Hermes agent-to-agent workflows live | [@gkisokay on X](https://x.com/gkisokay) |
+| GLADIATOR: 9 Hermes agents, two rival AI companies competing via GitHub stars | YouTube |
+| Telegram to Modal serverless — 40% faster on research tasks | Blog |
+| 5 apps built and launched in a single day | LinkedIn |
+| 8h/day on Opus: email pipeline with DBOS + Postgres + S3 | GitHub |
+| Audited 129 of my own sessions across 23 days via external RCA script | GitHub |
+| Skill Factory: silently watches workflows and writes SKILL.md + plugin.py | GitHub |
+| CCD multi-agent pod on an M2 Ultra with Mem0 + Qdrant | GitHub |
+| 73% of every API call is fixed overhead — built monitoring dashboard to profile token usage | GitHub |
+| Accumulates knowledge about my codebase over time | Blog |
+| **Kanban feature built into Hermes** — multi-agent kanban workflows for task orchestration | [u/itsdodobitch on Reddit](https://reddit.com/r/hermesagent/comments/1t4efcb/what_is_the_new_kanban_feature_built_into_hermes/) |
+| **Agent Studio — Zero Human Company** — orchestration layer for team of engineer agents | [u/labeebk on Reddit](https://reddit.com/r/hermesagent/comments/1t5024g/agent_studio_zero_human_company/) |
+| **Zero-token watchdog plugin** — monitors GitHub repos, RSS feeds, websites. Only notifies on changes | [u/JealousPlastic on Reddit](https://reddit.com/r/hermesagent/comments/1t5ibcc/i_built_a_zero-token_watchdog_plugin_for_hermes/) |
+| **Self-hosted multi-agent system with 2 Hermes instances coordinating via Syncthing** — JARVIS orchestrator delegates to specialist workers | [u/SpecialistPowerful23 on Reddit](https://reddit.com/r/hermesagent/comments/1t4ltbx/i_built_a_selfhosted_multiagent_system_with_2/) |
+| **Auto-generating agent skills from Apify Actors** — skill packages generated automatically from web scrapers | [u/Hayder_Germany on Reddit](https://reddit.com/r/hermesagent/comments/1t5p62c/experiment_autogenerating_agent_skills_from_apify/) |
+| **Hermes Agent Self-Evolution (early alpha)** — DSPy + GEPA to automatically evolve Hermes skills | [u/piggystarter on Reddit](https://reddit.com/r/hermesagent/comments/1t5ifvg/nous_research_just_dropped_hermes_agent/) |
+| **OpenCode integration plugin — dispatch coding tasks to multi-agent harness (17 stars)** | [zaycruz on GitHub](https://github.com/zaycruz/hermes-opencode-plugin) |
+| **Hermes autonomous server — systemd + native cron, production-ready headless setup (7 stars)** | [JackTheGit on GitHub](https://github.com/JackTheGit/hermes-autonomous-server) |
+| **Zo-oroboros swarm executors — Claude Code and Hermes integration (6 stars)** | [marlandoj on GitHub](https://github.com/marlandoj/zouroboros-swarm-executors) |
+| **DeerMes — Deerflow execution layer + Hermes learning layer (2 stars)** | [Hompeaz on GitHub](https://github.com/Hompeaz/DeerMes) |
+| **4 Anthropic-inspired agent features: Dreaming, Outcomes, Orchestration, Webhooks (PR #21212)** | [dashitongzhi on GitHub](https://github.com/NousResearch/hermes-agent/pull/21212) |
+| **Hermes Agent Self-Evolution (2872 stars)** — optimize skills, prompts, and code using DSPy + GEPA | [NousResearch on GitHub](https://github.com/NousResearch/hermes-agent-self-evolution) |
+| **Maestro — cross-agent coding conductor (151 stars)** — structured memory, handoffs, plan-approve-execute coordination | [ReinaMacCredy on GitHub](https://github.com/ReinaMacCredy/maestro) |
+| **Lossless Context Management plugin (424 stars)** — DAG-based context engine that never loses a message | [stephenschoettler on GitHub](https://github.com/stephenschoettler/hermes-lcm) |
+| **Hermes Labyrinth observability plugin (257 stars)** — journeys, crossings, guideposts, and reports | [stainlu on GitHub](https://github.com/stainlu/hermes-labyrinth) |
+| **Icarus plugin — self-memory and replacement models (110 stars)** — remember your work, train your replacement | [esaradev on GitHub](https://github.com/esaradev/icarus-plugin) |
+| **hermesctl — interactive control panel (18 stars)** — Bash + gum CLIProxy-style API menu | [byJoey on GitHub](https://github.com/byJoey/hermesctl) |
+| **Hermes setup skill — deploy via coding agents (4 stars)** — Claude Code, Codex, OpenCode, Cursor, Windsurf | [hqhq1025 on GitHub](https://github.com/hqhq1025/hermes-setup-skill) |
+| **Open Forge — AI-guided self-hosting for 950+ apps (38 stars)** — catalog self-improves with Hermes | [zhangqi444 on GitHub](https://github.com/zhangqi444/open-forge) |
+| **hermescheck — architecture and runtime health checks (35 stars)** | [huangrichao2020 on GitHub](https://github.com/huangrichao2020/hermescheck) |
+| **hermes-skills — bitwarden secrets, email composition, autoresearch loop (9 stars)** | [domvox on GitHub](https://github.com/domvox/hermes-skills) |
+| **Agenvoy — agentic runtime with multi-provider concurrent dispatch, self-improving error memory, pluggable tools (83 stars)** | [agenvoy on GitHub](https://github.com/agenvoy/Agenvoy) |
+| **hermes-nightshift-glm — autonomous overnight code quality bot (11 stars)** | [Microck on GitHub](https://github.com/Microck/hermes-nightshift-glm) |
+| **pi-until-done — Pi extension that executes raw user intent to completion with verifiable termination (16 stars)** | [srinitude on GitHub](https://github.com/srinitude/pi-until-done) |
+| **Ollama-Cloud-Hermes-Agent-Paperclip — route Paperclip agent swarm to Ollama Cloud models via resilient local proxy (1 star)** | [Vivere-Vitalis-LLC on GitHub](https://github.com/Vivere-Vitalis-LLC/Ollama-Cloud-Hermes-Agent-Paperclip) |
+| **ClawFleet — deploy a fleet of AI agents on your machine in 10 minutes, use ChatGPT subscription (142 stars)** | [clawfleet on GitHub](https://github.com/clawfleet/ClawFleet) |
+| **clawpier — desktop app for managing sandboxed AI agent instances via Docker, Tauri v2 (70 stars)** | [SebastianElvis on GitHub](https://github.com/SebastianElvis/clawpier) |
+| **ClawEnvKit — open-source environment toolkit for claw-like agents, task/harness generation and evaluation (37 stars)** | [xirui-li on GitHub](https://github.com/xirui-li/ClawEnvKit) |
+| **lowkey — deploy FullStack Coding Agent self-hosted in AWS Cloud (34 stars)** | [inceptionstack on GitHub](https://github.com/inceptionstack/lowkey) |
+| **Ankh.md — multi-agent swarm framework (50 stars)** | [Abruptive on GitHub](https://github.com/Abruptive/Ankh.md) |
+| **Network-AI — traffic light for AI Agents, TypeScript/Node multi-agent orchestrator with shared state, guardrails (45 stars)** | [Jovancoding on GitHub](https://github.com/Jovancoding/Network-AI) |
+| **hermes-go — AI Agent framework in Go with RAG, Knowledge, Memory, Tools (25 stars)** | [Harsh-2909 on GitHub](https://github.com/Harsh-2909/hermes-go) |
+| **bunny-agent — build coding agent SaaS via native AI SDK UI (15 stars)** | [buda-ai on GitHub](https://github.com/buda-ai/bunny-agent) |
+| **agent-mux — unified TypeScript SDK and CLI for driving heterogeneous coding-agent harnesses (9 stars)** | [a5c-ai on GitHub](https://github.com/a5c-ai/agent-mux) |
+| **tenbox — lightweight x86-64/arm64 Virtual Machine Monitor (VMM) for Hermes Agent (227 stars)** | [78 on GitHub](https://github.com/78/tenbox) |
+| **super-hermes — skills that teach Hermes Agent to write its own analytical prompts (144 stars)** | [Cranot on GitHub](https://github.com/Cranot/super-hermes) |
+| **hermes-dojo — self-improvement system that monitors performance, finds weak skills, fixes with self-evolution (53 stars)** | [Yonkoo11 on GitHub](https://github.com/Yonkoo11/hermes-dojo) |
+| **hermes-gate — terminal TUI for managing remote Hermes Agent sessions with auto-reconnect, detach support (21 stars)** | [LehaoLin on GitHub](https://github.com/LehaoLin/hermes-gate) |
+| **kali-pentest — AI agent skill for autonomous penetration testing via Kali Linux, 199 CLI tools, 15 scenario playbooks (10 stars)** | [x-glacier on GitHub](https://github.com/x-glacier/kali-pentest) |
+| **hermes-swe-agent — autonomous AI coding agent triggered by Linear tickets, spins up full dev environments on EC2 (10 stars)** | [Deepank308 on GitHub](https://github.com/Deepank308/hermes-swe-agent) |
+| **hermes-alpha — cloud deployed version of the Nous Research Hermes agent (194 stars)** | [kaminocorp on GitHub](https://github.com/kaminocorp/hermes-alpha) |
+| **hermes-for-win — one-click installation and deployment of Hermes Agent and WebUI for Windows (23 stars)** | [EdwardWason on GitHub](https://github.com/EdwardWason/hermes-for-win) |
+| **FlyEnv — lightweight native local dev toolbox for Windows/macOS/Linux, run Hermes/OpenClaw/n8n/Apache/Nginx (2787 stars)** | [xpf0000 on GitHub](https://github.com/xpf0000/FlyEnv) |
+| **captureos — three-basket capture router for Hermes Agent (2 stars)** | [theali2x on GitHub](https://github.com/theali2x/captureos) |
+| **cc-import — import Claude Code plugins (skills + agents) into Hermes Agent, translates personas into Hermes delegates (1 star)** | [roach88 on GitHub](https://github.com/roach88/cc-import) |
+| **hermes-plugin-diff-review — plugin that reviews git diffs for common code quality issues (1 star)** | [sprmn24 on GitHub](https://github.com/sprmn24/hermes-plugin-diff-review) |
+| **hermes-vscode — Hermes AI coding agent for VS Code, streams chat, runs tools, manages sessions, switches models (14 stars)** | [joaompfp on GitHub](https://github.com/joaompfp/hermes-vscode) |
+| **hermes-agent-desktop — Multi-Agent AI Desktop Client, 20 specialists auto-collaborate on your tasks, Visual Skill Store, PM orchestrator (13 stars)** | [Felix-Forever on GitHub](https://github.com/Felix-Forever/hermes-agent-desktop) |
+
+---
+
+## Integrations (51 retained rows)
+
+Connecting Hermes to external services: email, browsers, MCP tools, CRMs, home automation, and custom platforms.
+
+| Use Case | Source |
+|----------|--------|
+| Give your Hermes its own email inbox — no extra services needed | X |
+| Vessel Browser: agent-native browser born at the Hermes hackathon | Hacker News |
+| Firecrawl for scrape/search/browse integration | LinkedIn |
+| Hindsight Cloud memory connected | LinkedIn |
+| Hermes + Browser Harness on a Hostinger VPS — copy-paste setup | GitHub Gist |
+| Fat agent to thin tool provider via hermes mcp serve | GitHub Gist |
+| jMunch MCP: 52 tools via tree-sitter for code intelligence | GitHub |
+| Desktop computer-use module: noVNC, screenshots, mouse/keyboard | GitHub |
+| Cross-agent memory: Hermes + Claude Code + Cursor | GitHub |
+| Vercel Sandbox as a Hermes backend | GitHub |
+| Webchat: custom themed browser UI on MEMORY.md | GitHub |
+| Agent-to-agent commerce via Merxex | GitHub |
+| Hermes in Zed editor via ACP Registry | GitHub |
+| JMAP email for Fastmail users | GitHub |
+| Home Assistant add-on: zero to agent in under 5 minutes | X |
+| **One-Click Hermes Agent Container (Fox in the box)** — Docker container with PWA and mem0 persistent memory | [u/EmergencyCelery911 on Reddit](https://reddit.com/r/hermesagent/comments/1t4frvk/oneclick_hermes_agent_container_fox_in_the_box/) |
+| **Hermes Client** — web UI for local Hermes CLI with usage dashboards and spending limits (100+ stars) | [u/lotsoftick on Reddit](https://reddit.com/r/hermesagent/comments/1t4amfs/hermes_client_a_web_ui_for_your_local_hermes_cli/) |
+| **Prompt Vault plugin** — save, search, and reuse prompts from any platform | [u/JealousPlastic on Reddit](https://reddit.com/r/hermesagent/comments/1t4hrd4/i_built_a_prompt_vault_plugin_for_hermes_agent/) |
+| **Mnemosyne: memory system for Hermes Agents** | [u/AbdiiSan on Reddit](https://reddit.com/r/hermesagent/comments/1t4ujs5/mnemosyne_a_memory_system_for_hermes_agents/) |
+| **Hermes Memory Installer 2.0** — long-term memory with gbrain knowledge graph + PostgreSQL | [u/mage0535 on Reddit](https://reddit.com/r/hermesagent/comments/1t597dx/hermes_memory_installer_20_ai_longterm_memory/) |
+| **HermesAgent in rootless podman containers** | [u/WouterC on Reddit](https://reddit.com/r/hermesagent/comments/1t4t5x2/hermesagent_in_rootless_podman_containers/) |
+| **Home Assistant conversation integration for Hermes Agent (39 stars)** | [WolframRavenwolf on GitHub](https://github.com/WolframRavenwolf/hermes-ha-integration) |
+| **Microsoft Graph API skill — Outlook Calendar, Mail, Contacts (7 stars)** | [Andrew-Girgis on GitHub](https://github.com/Andrew-Girgis/microsoft-workspace-skill) |
+| **Eight Sleep Pod MCP server + Hermes integration (5 stars)** | [guglielmofonda on GitHub](https://github.com/guglielmofonda/8sleep-mcp) |
+| **ApkClaw Android app with HTTP API for remote Agent control (4 stars)** | [rfdiosuao on GitHub](https://github.com/rfdiosuao/Hermes-Agent-phone) |
+| **Anytype MCP integration skill (1 star)** | [Foolafroos on GitHub](https://github.com/Foolafroos/anytype-hermes-skill) |
+| **Human-Like Memory skill for Hermes (1 star)** | [qwang6-1936520 on GitHub](https://github.com/qwang6-1936520/Human-like-memory-skill) |
+| **OpenViking memory tool integration fork (1 star)** | [CUexter on GitHub](https://github.com/CUexter/hermes-agent) |
+| **Steel cloud browser provider for Hermes (PR #21182)** | [nibzard on GitHub](https://github.com/NousResearch/hermes-agent/pull/21182) |
+| **Hermes WebUI (6004 stars)** — best way to use Hermes Agent from the web or phone | [nesquena on GitHub](https://github.com/nesquena/hermes-webui) |
+| **hermes-web-ui (3841 stars)** — multi-platform AI chat, session management, scheduled jobs, usage analytics | [EKKOLearnAI on GitHub](https://github.com/EKKOLearnAI/hermes-web-ui) |
+| **Hermes workspace (3504 stars)** — native web workspace: chat, terminal, memory, skills, inspector | [outsourc-e on GitHub](https://github.com/outsourc-e/hermes-workspace) |
+| **Hermes for web (64 stars)** — personalized web workbench with setup packs, artifacts, memory-aware onboarding | [reallygood83 on GitHub](https://github.com/reallygood83/hermes-for-web) |
+| **Vessel Browser (63 stars)** — open source AI browser for Linux/Windows, durable state, MCP control, BYO model | [unmodeled-tyler on GitHub](https://github.com/unmodeled-tyler/vessel-browser) |
+| **Hermes progress tail (2 stars)** — live tool and reasoning progress tails across Discord, Telegram | [tickernelz on GitHub](https://github.com/tickernelz/hermes-progress-tail) |
+| **autograph — typed memory layer for always-on agents, schema-as-code for Obsidian (11 stars)** | [smixs on GitHub](https://github.com/smixs/autograph) |
+| **hermes-console — local-first web dashboard: runtime health, sessions, cron, skills, memory, files (7 stars)** | [shan8851 on GitHub](https://github.com/shan8851/hermes-console) |
+| **Hermes-iOS — camera, mic, health data, location, notifications for Hermes agents (6 stars)** | [dylan-buck on GitHub](https://github.com/dylan-buck/Hermes-iOS) |
+| **hermes-google-workspace — Gmail, Calendar, Tasks, Sheets, Docs, Drive, Contacts via OAuth2 (2 stars)** | [BruceLanLan on GitHub](https://github.com/BruceLanLan/hermes-google-workspace) |
+| **hermes-nextcloud — files, notes, calendar, tasks, contacts via WebDAV and CalDAV (2 stars)** | [adnw-vinc on GitHub](https://github.com/adnw-vinc/hermes-nextcloud) |
+| **hermes-apple-calendar-assistant — Apple Calendar skill (1 star)** | [adoramon on GitHub](https://github.com/adoramon/hermes-apple-calendar-assistant) |
+| **hermes-memory-keep-alive-for-obsidian — automatic task memory and keep-alive loop (14 stars)** | [TechieTer on GitHub](https://github.com/TechieTer/hermes-memory-keep-alive-for-obsidian) |
+| **obsidian-vault-graph — local knowledge graph CLI with backlinks, centrality, QMD hybrid retrieval (3 stars)** | [kartikkabadi on GitHub](https://github.com/kartikkabadi/obsidian-vault-graph) |
+| **aimx — SMTP for AI agents, no middleman (3 stars)** | [uzyn on GitHub](https://github.com/uzyn/aimx) |
+| **hermes-android — Android device control, bridge app + Python toolset (137 stars)** | [raulvidis on GitHub](https://github.com/raulvidis/hermes-android) |
+| **hermes-ui — command center: chat, steer, browse files, manage skills, monitor everything (102 stars)** | [pyrate-llama on GitHub](https://github.com/pyrate-llama/hermes-ui) |
+| **hermes-control-interface — self-hosted web dashboard: terminal, file explorer, session overview (605 stars)** | [xaspx on GitHub](https://github.com/xaspx/hermes-control-interface) |
+| **pan-ui — self-hosted AI workspace: chat, skills, extensions, memory, profiles, runtime controls (62 stars)** | [Euraika-Labs on GitHub](https://github.com/Euraika-Labs/pan-ui) |
+| **OpenClaw-Admin — Vue 3 AI agent management platform supporting OpenClaw and Hermes (692 stars)** | [itq5 on GitHub](https://github.com/itq5/OpenClaw-Admin) |
+| **hermes-weather-plugin — NWS-grade model imagery, NEXRAD radar, verified meteorological calculations in Rust (15 stars)** | [FahrenheitResearch on GitHub](https://github.com/FahrenheitResearch/hermes-weather-plugin) |
+| **hermes-agent-win-gui — Windows 10/11 fork with browser-based web dashboard, sessions, config, chat, terminal (3 stars)** | [631341689 on GitHub](https://github.com/631341689/hermes-agent-win-gui) |
+
+---
+
+## Personal Assistant (22 retained rows)
+
+Daily personal use: family assistants, home automation, health tracking, scheduling, and proactive AI helpers.
+
+| Use Case | Source |
+|----------|--------|
+| One Hermes for the whole family on WhatsApp — 3 members, one $200 ChatGPT sub | [@EXM7777 on X](https://x.com/EXM7777) |
+| Replaced everything with a single Hermes agent | X |
+| Jarvis at home in 2026 — m2.7 + Hermes | X |
+| Obsidian, home automation, VPS server management on a cheap VPS | Hacker News |
+| Apple Health, Threads analytics, Gmail, Calendar in one CLI | Blog |
+| Every weekday at 9am, summarize inbox and post to Slack | Blog |
+| Hermes over iMessage on always-on Mac Studio | GitHub |
+| Horse-racing Telegram community bot | GitHub |
+| Hermes running on a Pi 4 as home server | GitHub |
+| Bedtime stories for my daughter | GitHub |
+| One agent, many roles: nutritionist, developer, finance advisor | GitHub |
+| Proactive check-ins — "anything you want me to watch this afternoon?" | GitHub |
+| Sometimes Hermes Agent melts my heart | X |
+| Google Tasks integration | GitHub |
+| Private Telegram topics, each with its own skill bindings | Blog |
+| **SOUL.MD generator** — pick a template or describe your agent, get a personality file | [u/JealousPlastic on Reddit](https://reddit.com/r/hermesagent/comments/1t59352/i_built_a_soulmd_generator_for_hermes_pick_a/) |
+| **Local-first wellness profile pack** — recovery, training, wellness tracking | [u/delxmobile on Reddit](https://reddit.com/r/hermesagent/comments/1t5jfol/i_built_a_localfirst_wellness_profile_pack_for/) |
+| **24/7 personal AI agent on Galaxy Z Fold 6** — full-time agent living on phone | [u/fapas18 on Reddit](https://reddit.com/r/hermesagent/comments/1t4l28w/247_personal_ai_agent_running_on_a_galaxy_z_fold/) |
+| **Multi-agent profile setup ("Archiver")** — specialized agents for different roles | [u/itsdodobitch on Reddit](https://reddit.com/r/hermesagent/comments/1t66lhy/my_simplest_yet_effective_hermes_agent_profile/) |
+| **Personal API skill — turn your Obsidian vault into a personal identity layer, any AI agent knows who you are in 30s (14 stars)** | [beiyuii on GitHub](https://github.com/beiyuii/personal-api-skill) |
+| **The Forge Protocol Agent — anti-deskilling framework, human-AI collaboration protocol (3 stars)** | [lorenzofamiglini on GitHub](https://github.com/lorenzofamiglini/The-Forge-Protocol-Agent) |
+| **hermes_stack — personal AI agent setup with Hermes + gbrain + growing library of real-world skills (1 star)** | [kongaharsha on GitHub](https://github.com/kongaharsha/hermes_stack) |
+
+---
+
+## Meta & Ecosystem (28 retained rows)
+
+Community tools, installers, migration guides, and ecosystem-building projects.
+
+| Use Case | Source |
+|----------|--------|
+| Scraped the entire Hermes ecosystem (hermesatlas.com) | X |
+| Show HN: independent install guide | Hacker News |
+| Hermify: managed hosting for Hermes | [u/somratpro on Reddit](https://reddit.com/r/hermesagent/comments/1t3ne3a/run_hermes_agent_on_hugging_face_spaces_for_free/) |
+| Native Windows app wrapper for Hermes | [Reddit](https://reddit.com/r/hermesagent) |
+| hermes-for-win: one-click Windows installer | GitHub |
+| Shadow-to-live migration path from OpenClaw | GitHub |
+| Switched from OpenClaw, not looking back | X |
+| Hermes Agent has won. Here's why. | Podcast |
+| awesome-hermes-agent: community-curated skills list | GitHub |
+| "The best self-improving agent we've used" | [Product Hunt](https://www.producthunt.com) |
+| **Hermes Agent Wiki now live at hermesguide.xyz/wiki** — community wiki based on subreddit knowledge | [u/SelectionCalm70 on Reddit](https://reddit.com/r/hermesagent/comments/1t5k1t1/the_hermes_agent_wiki_for_subreddit_is_now_live/) |
+| **awesome-hermes-agent: curated list of skills, tools, integrations (2654 stars)** | [0xNyk on GitHub](https://github.com/0xNyk/awesome-hermes-agent) |
+| **Hermes Atlas — community map of every tool, skill, and integration (763 stars)** | [ksimback on GitHub](https://github.com/ksimback/hermes-ecosystem) |
+| **awesome-hermes-skills: production-ready skills collection (49 stars)** | [ChuckSRQ on GitHub](https://github.com/ChuckSRQ/awesome-hermes-skills) |
+| **Hermes optimization guide (263 stars)** — setup, migration, LightRAG, Telegram, skill creation | [OnlyTerp on GitHub](https://github.com/OnlyTerp/hermes-optimization-guide) |
+| **hermes-skills — 310+ reusable AI agent workflows for coding, marketing, design, finance, MLOps (5 stars)** | [itgoyo on GitHub](https://github.com/itgoyo/hermes-skills) |
+| **Hermes setup guide — local AI model, Telegram bot, TurboQuant acceleration (1 star)** | [JulCCrum on GitHub](https://github.com/JulCCrum/hermes-setup-guide) |
+| **learn-hermes-agent — 27-chapter hands-on tutorial for building autonomous AI agent from zero (87 stars)** | [longyunfeigu on GitHub](https://github.com/longyunfeigu/learn-hermes-agent) |
+| **memo-agent — terminal-based AI assistant (Hermes simplified), TypeScript + React (5 stars)** | [lxfu1 on GitHub](https://github.com/lxfu1/memo-agent) |
+| **awesome-HermesAgent-tutorial — comprehensive tutorial: learning loops, cross-platform messaging, 200+ model routing (6 stars)** | [xianyu110 on GitHub](https://github.com/xianyu110/awesome-HermesAgent-tutorial) |
+| **alblez/hermes-skills — collection of reusable skills (10 stars)** | [alblez on GitHub](https://github.com/alblez/hermes-skills) |
+| **hurmoz — 63 Arabic AI skills for Hermes Agent, first and largest Arabic skills collection (6 stars)** | [Moshe-ship on GitHub](https://github.com/Moshe-ship/hurmoz) |
+| **hermes-howto — comprehensive step-by-step guide and best practices for mastering Hermes Agent (5 stars)** | [1234567mm on GitHub](https://github.com/1234567mm/hermes-howto) |
+| **agency-agents-zh — 211 plug-and-play AI expert roles, supports Hermes/Claude Code/Cursor/Copilot, 18 departments (10084 stars)** | [jnMetaCode on GitHub](https://github.com/jnMetaCode/agency-agents-zh) |
+| **superpowers-zh — AI programming superpowers Chinese enhanced edition, 116k+ stars original + 6 China-original skills (2198 stars)** | [jnMetaCode on GitHub](https://github.com/jnMetaCode/superpowers-zh) |
+| **hermes-skill-marketplace — self-evolving Hermes agent that writes, tests, and publishes reusable Skills autonomously (13 stars)** | [Lethe044 on GitHub](https://github.com/Lethe044/hermes-skill-marketplace) |
+| **awesome-hermes-skills — curated install-ready skills for Hermes Agent, 85 built-in + 78 community skills, plugins, and tools (5 stars)** | [ZeroPointRepo on GitHub](https://github.com/ZeroPointRepo/awesome-hermes-skills) |
+| **awesome-hermes-usecases — curated real-world use cases for Hermes Agent backed by primary sources (31 stars)** | [aliaihub on GitHub](https://github.com/aliaihub/awesome-hermes-usecases) |
+
+---
+
+## Business Ops (17 retained rows)
+
+Client management, CRM, sales outreach, inventory tracking, and business process automation.
+
+| Use Case | Source |
+|----------|--------|
+| Client research, follow-ups, podcasts, leads — all on Hermes | X |
+| Live inventory tracking on Hermes with 40+ built-in tools | X |
+| Day 297 of streak: $100K of client work automated | X |
+| Auto-transcribe Meet calls, control from Teams, local models for client data | Blog |
+| 24/7 assistant with a Supabase CRM, built in a demo | YouTube |
+| Task-centric memory for a printing factory | GitHub |
+| **B2B SDR skill (7 stars)** — autonomous AI sales dev rep: finds buyers, qualifies leads, sends outreach, manages CRM across WhatsApp/Email/Telegram | [iPythoning on GitHub](https://github.com/iPythoning/b2b-sdr-hermes-skill) |
+| Create and edit Google Slides decks via google-workspace skill | GitHub |
+| Hunter.io email-finding for sales outreach via Composio | GitHub |
+| **provision-core — open-source AI workforce platform: agents with tasks, tools, browsers, email (17 stars)** | [provision-org on GitHub](https://github.com/provision-org/provision-core) |
+| **discord-meeting-recorder — self-hosted Discord meeting transcription with AI-generated reports (1 star)** | [elghaied on GitHub](https://github.com/elghaied/discord-meeting-recorder) |
+| **hermes-legal — autonomous contract risk analysis, scores clauses, suggests negotiation language (3 stars)** | [Lethe044 on GitHub](https://github.com/Lethe044/hermes-legal) |
+| **my-pretty-decent-skills — battle-tested multi-agent workflows for supply chain threat intel (1 star)** | [AI-1409 on GitHub](https://github.com/AI-1409/my-pretty-decent-skills) |
+| **hermes-merchant — portable agent skills that scrape ML/AI jobs, score against profile, auto-fill Greenhouse applications (28 stars)** | [arimanyus on GitHub](https://github.com/arimanyus/hermes-merchant) |
+| **hermes-pm-toolkit — self-writing skills for PMs running on Hermes agent runtime, competitive analysis workflows (5 stars)** | [aakashg on GitHub](https://github.com/aakashg/hermes-pm-toolkit) |
+| **h-ops — Hermes Agent operations cockpit for Kanban: health, assignment, progress, logs, output, run history (2 stars)** | [tmdgusya on GitHub](https://github.com/tmdgusya/h-ops) |
+| **agent-team-orchestrator — document-first multi-agent product organization pack for Hermes with role boundaries, handoff contracts, review gates (1 star)** | [DeclanJeon on GitHub](https://github.com/DeclanJeon/agent-team-orchestrator) |
+
+---
+
+## Enterprise (7 retained rows)
+
+Production deployments, compliance, Kubernetes, GCP Vertex AI, and enterprise-grade infrastructure.
+
+| Use Case | Source |
+|----------|--------|
+| Hermes inside an MCP infrastructure behind Higress | GitHub |
+| EU AI Act compliance via Ombre — tamper-proof audit trail | GitHub |
+| Kubernetes pod-hop handoff across restarts | GitHub |
+| Vertex AI for GCP-standardized enterprises | GitHub |
+| Hermes as CLI/gateway-first — 13 platforms under one process | Blog |
+| Azure-compliant prompt patch so the safety filter doesn't kick in | GitHub Gist |
+| **hermes-multitenancy — one Feishu bot, N users, N profiles, multi-tenant routing plugin (2 stars)** | [eggyrooch-blip on GitHub](https://github.com/eggyrooch-blip/hermes-multitenancy) |
+
+---
+
+## Content Creation (8 retained rows)
+
+Voice-matched writing, YouTube scripts, social media content, and creative publishing workflows.
+
+| Use Case | Source |
+|----------|--------|
+| Monica that writes in my voice | X |
+| Scraped Amazon without extra config; built a YouTube title skill | YouTube |
+| Tweets in my voice, pulled from past video scripts | YouTube |
+| **YouTube skills (174 stars)** — transcript API, video search, channel browsing for AI agents | [ZeroPointRepo on GitHub](https://github.com/ZeroPointRepo/youtube-skills) |
+| Weekly cron: top 3 trending AI tools for next video | YouTube |
+| LinkedIn posts that remember my style | YouTube |
+| **obsidian-video-notes — video-to-note workflow, transcribes audio via faster-whisper, generates structured Markdown (2 stars)** | [lomychenbao-bit on GitHub](https://github.com/lomychenbao-bit/obsidian-video-notes) |
+| **Noustiny — agent native video creation pipeline on top of Hermes Agent (75 stars)** | [UfukNode on GitHub](https://github.com/UfukNode/Noustiny) |
+
+---
+
+## Cost Optimization (6 retained rows)
+
+Running Hermes cheap: VPS setups, model selection, token reduction, and budget hosting.
+
+| Use Case | Source |
+|----------|--------|
+| Under $20/mo total — no Mac Mini, no Opus | Blog |
+| Hetzner VPS at $10/mo, Claude Opus via OpenRouter | YouTube |
+| 90% token spend cut. Runs on a cheap Android via Termux | Podcast |
+| $5 VPS playbook so the defaults don't eat your OpenRouter budget | Blog |
+| **Run Hermes Agent on Hugging Face Spaces for FREE (24/7)** | [u/somratpro on Reddit](https://reddit.com/r/hermesagent/comments/1t3ne3a/run_hermes_agent_on_hugging_face_spaces_for_free/) |
+| **LLM keypool (24 stars)** — free-tier API key pool with rotation, cooldown handling, OpenAI-compatible proxy | [piyush-tyagi-13 on GitHub](https://github.com/piyush-tyagi-13/llm-keypool) |
+
+---
+
+## Creative (21 retained rows)
+
+Video generation, generative art, music, and creative media production.
+
+| Use Case | Source |
+|----------|--------|
+| My Hermes agent makes movies now — browser_use + Seedance 2.0, no API needed | [@alexcovo_eth on X](https://x.com/alexcovo_eth) |
+| shadcn finance dashboard + Manim explainer videos | YouTube |
+| Generative visuals in TouchDesigner via Hermes skill | GitHub |
+| **Hermes Agent generates full videos with HyperFrames** — HTML/CSS/JS/GSAP animations rendered to MP4 | [u/SelectionCalm70 on Reddit](https://reddit.com/r/hermesagent/comments/1t4kcup/hermes_agent_now_generates_full_videos_with/) |
+| **The Holographic Mind: AI that thinks, feels, and writes philosophy** — two-week build | [u/petriko on Reddit](https://reddit.com/r/hermesagent/comments/1t4meas/the_holographic_mind_how_i_built_an_ai_that/) |
+| **Hermes Agent integration for Open-LLM-VTuber (3 stars)** | [123mikeyd on GitHub](https://github.com/123mikeyd/hermes-vtuber) |
+| **Codex imagegen skill (22 stars)** — generate images directly in Hermes using ChatGPT Codex CLI | [madrobotnet on GitHub](https://github.com/madrobotnet/hermes-codex-imagegen-skill) |
+| **drawio-skill — from text to professional diagrams, generates draw.io diagrams from natural language (1254 stars)** | [Agents365-ai on GitHub](https://github.com/Agents365-ai/drawio-skill) |
+| **visual-skills — professional AI image and video prompting for Gemini 3 Pro/Flash, GPT Image 2 (26 stars)** | [smixs on GitHub](https://github.com/smixs/visual-skills) |
+| **Wizards-of-the-Ghosts — unofficial Hermes Agent skill pack built from fantasy spell and skill names (77 stars)** | [Hmbown on GitHub](https://github.com/Hmbown/Wizards-of-the-Ghosts) |
+| **hermes-music-plugin — music generation plugin: Suno AI, MIDI composition, library management (5 stars)** | [buckster123 on GitHub](https://github.com/buckster123/hermes-music-plugin) |
+| **meme-library — meme library skill with visual auto-tagging + semantic search, agent picks perfect meme on demand (1 star)** | [yr-96 on GitHub](https://github.com/yr-96/meme-library) |
+| **Heimdall-SL-Hermes-Agent — autonomous Second Life Agent for the Gridweaver (2 stars)** | [hrabanazviking on GitHub](https://github.com/hrabanazviking/Heimdall-SL-Hermes-Agent) |
+| **DocFlow-Presentations-and-Docs-Skill — agent-first Python skill for Hermes & OpenClaw: DOCX/XLSX/PDF/PPTX via OfficeSuite, HTML template catalog (1 star)** | [rafalozan0 on GitHub](https://github.com/rafalozan0/DocFlow-Presentations-and-Docs-Skill) |
+| **crimson-desert-companion — complete Crimson Desert game database & AI companion, 9,288 rows, 34 query actions, Hermes skill (1 star)** | [b7216309-jpg on GitHub](https://github.com/b7216309-jpg/crimson-desert-companion) |
+| **hermes-embodied — self-improving robotics via Hermes Agent, provisions cloud GPUs, fine-tunes VLA models, runs sim evaluation (6 stars)** | [bryercowan on GitHub](https://github.com/bryercowan/hermes-embodied) |
+| **caduceus-robot — Hermes Agent's physical form, voice-controlled robot for the Hermes Agent Creative Hackathon (4 stars)** | [devorun on GitHub](https://github.com/devorun/caduceus-robot) |
+| **robot-bridge — StackChan Robot Bridge, connect ESP32 to Hermes Agent (1 star)** | [waynecc-at on GitHub](https://github.com/waynecc-at/robot-bridge) |
+| **waifu-sprites — Codex Pets for hermes-agent, dashboard plugin with multi-pet support (12 stars)** | [waifuai on GitHub](https://github.com/waifuai/waifu-sprites) |
+| **agent-pet — lightweight desktop companion for AI tools and agent activity, supports Codex-compatible sprite sheets (11 stars)** | [xiangking on GitHub](https://github.com/xiangking/agent-pet) |
+| **hermes-game-dev-studio — turn Hermes Agent into a full game development studio (1 star)** | [laok775 on GitHub](https://github.com/laok775/hermes-game-dev-studio) |
+
+---
+
+## Research (9 retained rows)
+
+Research agents, knowledge bases, academic tools, and information synthesis.
+
+| Use Case | Source |
+|----------|--------|
+| Daily research brief across Discord, Slack, Notion & Obsidian — watches AI/agent space | [@gkisokay on X](https://x.com/gkisokay) |
+| I had my research agent dig into what people are building with Hermes | [Reddit](https://reddit.com/r/hermesagent) |
+| A self-improving LLM Wiki second brain — knowledge base that compounds over time | Blog |
+| LaTeX math renders properly in the TUI | GitHub |
+| **Agentic SWMM workflow — stormwater modeling with QA verification (4 stars)** | [Zhonghao1995 on GitHub](https://github.com/Zhonghao1995/agentic-swmm-workflow) |
+| **Hermes web search plus (156 stars)** — multi-provider web search with intelligent routing, quality reports, research mode | [robbyczgw-cla on GitHub](https://github.com/robbyczgw-cla/hermes-web-search-plus) |
+| **hermes-agent_Video-Research-Ingest — local-first video research ingest pipeline, videos and URLs into markdown notes (historical entry)** | Repository returned 404 when checked July 16, 2026; retained for provenance pending a corrected source |
+| **hermes-weather-agent — MCP tools for AI-driven weather model training, rustmet + metrust powered (7 stars)** | [FahrenheitResearch on GitHub](https://github.com/FahrenheitResearch/hermes-weather-agent) |
+| **askaipods — search AI podcast quotes by topic, find what Lex Fridman, Dwarkesh Patel, No Priors guests said (2 stars)** | [Delibread0601 on GitHub](https://github.com/Delibread0601/askaipods) |
+
+---
+
+## Messaging (7 retained rows)
+
+Platform adapters for LINE, QQ, Feishu/Lark, Discord, and regional messaging apps.
+
+| Use Case | Source |
+|----------|--------|
+| LINE for 95M+ users in Japan | GitHub |
+| QQ Bot adapter for China | GitHub |
+| Give Hermes hands inside Feishu (Lark) — full ecosystem coverage | GitHub |
+| DM-based approval gate for kid-facing Discord bots | GitHub |
+| **WeChat messaging integration with cron delivery** | [NousResearch on GitHub](https://github.com/NousResearch/hermes-agent/pull/21196) |
+| **OctoMatrix — autonomous AI command center for Telegram, Discord & Slack with long-term memory via grep-based RAG (1 star)** | [meso4444 on GitHub](https://github.com/meso4444/OctoMatrix) |
+| **hermes-agent-qq-gateway — standalone QQ Official Bot gateway (1 star)** | [zhaoxuya520 on GitHub](https://github.com/zhaoxuya520/hermes-agent-qq-gateway) |
+
+---
+
+---
+
+## Comment-Sourced Updates
+
+- **Link integrity:** commenters reported broken links; the author later audited and corrected/removed links. This repository copy still requires automated link checking because external targets continue to change.
+
+- **Outcome claims:** revenue, throughput, time-saved, and business-result numbers are community reports unless a primary source or reproducible artifact is provided.
+
+- **Make entries actionable:** comments favored SOP-style entries with the problem, tools, steps, output, and source rather than an undifferentiated list. Use issues/PRs to improve individual entries.
+
+## Maintaining this guide
+
+Open an issue or pull request with the official source, date checked, Hermes/backend version, and enough reproduction detail to evaluate the change. No referral links, affiliate links, or unsupported promotional claims.

--- a/megathreads/integrations-plugins-skills-2026-06.md
+++ b/megathreads/integrations-plugins-skills-2026-06.md
@@ -1,0 +1,443 @@
+# Integrations, Plugins & Skills Ecosystem Megathread — Hermes Agent (June 2026)
+
+> Community-maintained GitHub version of the Reddit megathread.
+>
+> Original Reddit thread: https://www.reddit.com/r/hermesagent/comments/1ui5a91/integrations_plugins_skills_ecosystem_megathread/
+>
+> **Snapshot:** Original post preserved and normalized; comment corrections reviewed through July 16, 2026.
+>
+> Time-sensitive prices, quotas, versions, model availability, benchmarks, and third-party project claims remain dated snapshots unless an official source is cited.
+
+---
+
+**LAST UPDATED: June 28, 2026** | **Scope: Late April – June 28, 2026 (includes threads from today) | ~42 threads analyzed** | **Megathread — Reference resource**
+
+This is the community's collective knowledge on connecting Hermes Agent to everything else — messaging platforms, productivity apps, home automation, developer tools, MCP servers, webhooks, and the Skills Hub. Built from subreddit discussions, X/Twitter, and official Hermes docs.
+
+---
+
+## TL;DR — Quick Reference
+
+| Use Case | Community Pick | Runner-Up | Notes |
+|----------|---------------|-----------|-------|
+| Multi-platform messaging | Telegram (native gateway) | Discord | WhatsApp (official adapter in v0.17.0), Signal, iMessage (Photon Spectrum), SimpleX |
+| Notes & knowledge base | Obsidian vault skill | Notion API | Obsidian wins on local-first + markdown |
+| Email | Himalaya CLI (IMAP/SMTP) | Google Workspace for agent | Personal Gmail risky — Google bans bot activity |
+| Calendar | Google Calendar via gws CLI | Apple Calendar (macOS) | Cron + calendar = automated scheduling |
+| Home automation | Home Assistant custom integration | MQTT bridge | HA add-on v1.1.0 supports multi-profile |
+| MCP server management | Built-in MCP Catalog | Manual stdio config | Catalog = one-click install for Nous-approved MCPs |
+| API/webhook automation | Webhooks adapter + GitHub | n8n + Hermes | Webhooks support HMAC signature validation |
+| Secret management | MCP + local password manager | `~/.hermes/.env` | Never store API keys in plaintext config |
+| Skill discovery | Skills Hub (90K+ skills) | Subreddit showcases | Quality varies — check recency and reviews |
+| Browser automation | Browserbase web skill library | Built-in browser tools | External web skill library gaining traction |
+| E-commerce / business | Custom MCP tools (Shopify, Amazon) | n8n workflows | Most community-built, not off-the-shelf |
+
+---
+
+## Part 1: Messaging Platforms — Where Hermes Lives
+
+Hermes Agent ships with native gateway support for Telegram, Discord, WhatsApp, Signal, and email. Setup is straightforward through the dashboard, but the community has surfaced key patterns and pitfalls.
+
+### Telegram (Community Favorite)
+
+By far the most-used messaging platform. Key findings from the subreddit:
+
+- **Setup:** Native gateway via `hermes gateway telegram`. Most users run this on a VPS for 24/7 availability.
+- **Multiple bots, one instance:** Users have successfully run multiple Telegram bots from one Hermes instance by configuring separate profiles with per-profile API tokens. [thread: "Multiple Telegram Bots on VPS with one Hermes Instance?", May 18](https://www.reddit.com/r/hermesagent/comments/1tg5edt/)
+- **Message formatting:** Hermes can struggle with Telegram's markdown formatting — specifically code blocks and tables. Workaround: configure the agent to use simpler formatting or pre-process output. [thread: "Can't get it to fix the format of telegram messages", May 27](https://www.reddit.com/r/hermesagent/comments/1tpoeht/)
+- **Group chat history:** Hermes doesn't automatically see prior chat history in Telegram groups. Explicitly reference or quote context if needed. [thread: "Hermes doesn't see chat history in Telegram groups", May 19](https://www.reddit.com/r/hermesagent/comments/1tiqg88/)
+
+### Discord
+
+- Gateway setup similar to Telegram. Less discussed but well-supported.
+- Context is shared across platforms — same agent, same memory, different UI. [thread: "Is context shared across messaging platforms?", Apr](https://www.reddit.com/r/hermesagent/comments/1slajqe/)
+
+### WhatsApp & Signal
+
+- Available via gateway. Lower community volume but functional.
+- **v0.17.0 (Jun 19): Official WhatsApp Business Cloud API adapter** — first-party, hosted, no bridge process. Alongside the existing Baileys bridge. `hermes gateway whatsapp` for setup.
+- Setup through dashboard — similar pattern to Telegram/Discord.
+
+**Community Spotlight — WhatsApp in Production (Jun 28, 2026):**
+A community member shared a real production setup using OpenWA (self-hosted WhatsApp API) + Hermes Agent to manage 11 construction WhatsApp groups:
+- Hermes reads all group messages (tower crane updates, QA/QC reports, manpower tracking, safety alerts)
+- Summarizes 82 WhatsApp messages into 3 lines: *"L970 Tower Crane: 52 lifts, TC 2 dominant. Jacking postponed — hydraulic issue. QA/QC: 23+2 workers, Block A L6-L7 vent block ongoing."*
+- Sends scheduled messages (e.g., check rebar balance, follow up on insurance)
+- Stack: OpenWA (self-hosted on laptop, localhost) → Hermes Agent (REST API) → Cronjobs → Telegram control interface
+- Runs on 8GB laptop, no monthly SaaS fees, no cloud dependency
+- Natural language in Manglish: *"Check L970 groups ada apa update hari ni."* Hermes understands context.
+- Community questions focused on hallucination prevention and WhatsApp ToS compliance (OpenWA is not officially sanctioned — the new official Business Cloud API adapter is the first-party alternative)
+
+[thread: "I turned Hermes Agent into my construction site assistant. It now manages my WhatsApp.", 35 upvotes, 11 comments, Jun 28](https://www.reddit.com/r/hermesagent/comments/1uhyift/)
+
+### iMessage (New in v0.17.0)
+
+- **Photon Spectrum — no Mac relay required.** `hermes photon login` (device-code OAuth), gRPC-native channel, markdown rendering, emoji reactions, outbound media. This replaces the old macOS-only `imsg` CLI approach.
+- Previously required a Mac running the `imsg` CLI — now available on any platform.
+
+### SimpleX (New in v0.17.0)
+
+- Groups, native attachments, text batching, auto-accept. Bundled platform plugin.
+- Privacy-focused messaging with no phone number required.
+
+### Email
+
+- **Himalaya CLI** is the community's preferred IMAP/SMTP tool — works well for agent-driven email.
+- **Gmail risk:** Multiple users report Google banning accounts used by Hermes for bot-like activity. Strong consensus: use Google Workspace (paid) for the agent's email, not a free personal Gmail. One user: "after one day Google blocked a gmail account I made for Hermes." [thread: "Gmail banned with hermes why!?!", May 27](https://www.reddit.com/r/hermesagent/comments/1tpgwp7/)
+- Dedicated email provider (e.g., Fastmail, Proton Mail with bridge) recommended for agent-only accounts.
+
+### Community Preference Poll
+
+From the "Which messaging channel do you use?" thread (Apr 29):
+- Telegram: dominant
+- Discord: second
+- WhatsApp/Signal: smaller but growing
+- Email: niche (used for specific workflows, not primary chat)
+
+---
+
+## Part 2: Productivity & Knowledge Integrations
+
+### Obsidian — The Community Standard for Knowledge Management
+
+The [most-engaged post](https://www.reddit.com/r/hermesagent/comments/1stz6gd/) in r/hermesagent history (1,029 upvotes, 179 comments, Apr 24) is a comprehensive Obsidian-as-memory-backbone guide. The core architecture that resonated with the community:
+
+**Three-Tier Memory System:**
+- **Tier 1 — Hot Memory:** Per-session context (~9K chars). When it hits ~67% capacity, stable entries get promoted to vault files.
+- **Tier 2 — Vault Living Files:** Stable reference material (environment configs, known failure patterns). Agent reads on-demand.
+- **Tier 3 — Daily Notes:** `Daily/YYYY-MM-DD.md` with tasks, schedule, log, wins. Searchable decision history.
+
+**Key patterns from the 179 comments:**
+- SyncThing integration for syncing VPS work folders to local Obsidian
+- Cross-agent memory: users running Hermes + Claude Code pointed at the same vault path
+- Windows PowerShell version of the scaffold script posted and tested
+
+**Obsidian vs Notion:** Community consensus favors Obsidian — local markdown files, no API rate limits, wiki-links create connection graphs. Notion cited for collaboration but API rate limiting remains an issue. [thread: "Obsidian or Notion", Apr 29](https://www.reddit.com/r/hermesagent/comments/1syvg1e/)
+
+### Notion
+
+- Notion API skill available (`notion` skill) — pages, databases, markdown, Workers.
+- Users who prefer Notion cite better collaboration features and rich database views.
+- Rate limiting and API latency are the main complaints vs Obsidian's local files.
+
+### Google Workspace
+
+- **Gmail:** gws CLI skill for reading/sending email. Works well with Google Workspace accounts. Free Gmail = ban risk.
+- **Calendar:** Google Calendar via gws CLI. Common pattern: cron job checks calendar → Hermes summarizes day ahead.
+- **Drive:** File management via gws CLI. Used for document storage and retrieval.
+- **Sheets/Docs:** Read/write via gws CLI. Used for expense tracking, reporting, data logging.
+
+### Apple Ecosystem
+
+- **Apple Notes:** `memo` CLI skill available. Community reports occasional issues with the skill.
+- **Apple Reminders:** `remindctl` CLI skill — add, list, complete.
+- **iMessage:** Photon Spectrum plugin — `hermes photon login` (device-code OAuth). No Mac relay required (new in v0.17.0). The old `imsg` CLI remains available for macOS users.
+
+### Other Productivity Tools
+
+- **Todoist:** API integration for task management. Mentioned in Obsidian thread as external data source.
+- **Excel/Spreadsheets:** Hermes can read/write `.xlsx` files natively. Users report permission prompts for financial data files — the safety layer flags these. [thread: "Hermes keeps asking permission to read/write my expense Excel", Jun 1](https://www.reddit.com/r/hermesagent/comments/1tu458c/)
+- **Himalaya CLI:** IMAP/SMTP email client, preferred for agent-driven email workflows.
+
+---
+
+## Part 3: Home Automation & IoT
+
+### Home Assistant (HA)
+
+The dominant home automation platform for Hermes users. Active community development:
+
+- **Official add-on:** WolframRvnwlf maintains a Hermes Agent Home Assistant Add-on that takes you "from zero to working agent in less than 5 minutes." [X: @WolframRvnwlf, Mar 27]
+- **v1.1.0 (Jun 1, 2026):** Added multi-profile support — run multiple Hermes agents side by side with per-profile env, dashboard, terminal, and API routes.
+- **Voice loop:** Full wake-word → STT → Hermes → TTS → speaker pipeline. Custom integration connects Hermes as a native Conversation Agent in HA. [X: @WolframRvnwlf, Apr 4]
+- **Limitations:** Hermes can read HA entity states but cannot directly edit automations through the standard integration. Community workaround: use YAML file editing or MQTT-based approaches. [thread: "Hermes can't edit Home Assistant automations", Apr 30](https://www.reddit.com/r/hermesagent/comments/1szxyr4/)
+
+### HA vs Bespoke
+
+Community consensus from the "Hermes home automation: use Home Assistant or bespoke?" thread (Jun 16):
+- **Use Home Assistant** for most home automation tasks — "it is far more mature than any of the agent tools, and the majority of all home automation tasks are better handled by HA directly."
+- **Use Hermes** as the intelligence layer on top — natural language control, scheduling, anomaly detection, and multi-step automation coordination.
+- **Do NOT** try to replace HA with Hermes — the integrations ecosystem (Zigbee, Z-Wave, Matter, 3000+ devices) is irreplaceable.
+
+### Other IoT Patterns
+
+- **MQTT bridge:** Direct MQTT topic subscription for sensor data ingestion.
+- **Camera feeds:** Hermes can receive camera snapshots via webhooks or file monitoring.
+- **Sensor data logging:** Cron job reads HA entity states → writes to Obsidian vault or database.
+
+---
+
+## Part 4: Developer Tools & MCP
+
+### MCP (Model Context Protocol) — The Extension Backbone
+
+MCP is Hermes's primary mechanism for connecting to external tool servers. Key facts from the official docs and community:
+
+- **Built-in MCP Catalog:** One-click install for Nous-approved MCP servers. Commands: `hermes mcp` (interactive picker), `hermes mcp install <name>` (install by name). [X: @NousResearch, May 27 — 107 replies]
+- **Two server types:** Stdio (local subprocesses) and HTTP (remote endpoints with OAuth support).
+- **OAuth 2.1 support:** Linear, Sentry, Atlassian, Asana, Figma, Stripe — tokens cached at `~/.hermes/mcp-tokens/`.
+- **Tool selection at install:** Interactive checklist — pick which specific tools to expose to the agent.
+- **Trust model:** Catalog entries gated by PR review into the hermes-agent repo. Always read the manifest's `source:` and `install.bootstrap:` fields.
+
+### Community-Built MCP Tools
+
+- **E-commerce MCP:** Shopify, Amazon, and Google Maps tools for product intelligence, inventory, and location data. Built by a community member. [thread: "Built 3 MCP tools for e-commerce intelligence"](https://www.reddit.com/r/hermesagent/comments/1srp2wt/)
+- **Web analytics plugin:** Multi-project analytics dashboard plugin. [thread: "Built a Hermes plugin for multi-project web analytics", Apr 21](https://www.reddit.com/r/hermesagent/comments/1srp2wt/)
+- **n8n + Hermes + MCP:** Community setup combining n8n for visual workflow automation with Hermes MCP for intelligent tool selection. [thread: "I built a complete Hermes Agent Desktop setup with MCPs, voice mode and n8n", Jun ~10](https://www.reddit.com/r/hermesagent/comments/1u245ua/)
+- **xurl CLI:** X Developers published official guide to connect Hermes with xurl for X/Twitter integration via xAI's Grok. [X: May 20]
+
+### Webhooks
+
+Hermes ships a webhook adapter that:
+- Runs an HTTP server accepting POST requests
+- Validates HMAC signatures
+- Transforms payloads into agent prompts
+- Routes responses back to source or another platform
+
+Common use cases: GitHub PR notifications → Hermes review, Stripe payment events → agent logging, JIRA ticket updates → agent response.
+
+### GitHub Integration
+
+- **gh CLI:** Full GitHub workflow — clone, create PRs, review code, manage issues.
+- **Webhooks:** GitHub → Hermes for automated PR review, issue triage, CI/CD notifications.
+- **MCP GitHub server:** Stdio-based server for deeper GitHub API access.
+
+---
+
+## Part 5: The Skills Ecosystem
+
+The Skills Hub launched in April 2026 and has exploded. As of June 2026: **90,000+ skills available**. The community has shifted from basic chat to skill-driven automation.
+
+### Skills Hub Overview
+
+- **Discovery:** Browse and install skills from the Skills Hub (dashboard or `hermes skills` CLI).
+- **Quality signals:** Recency, install count, author reputation, and community reviews help filter noise. No centralized rating system — rely on subreddit recommendations.
+- **Self-evolving skills:** Hermes can create and improve its own skills based on experience. The skill-audit pattern (review → patch → test) is the community standard.
+
+### Community Favorite Skills
+
+From the "10 skills" community thread (Jun 20) and wider subreddit discussion, the most frequently mentioned and endorsed skills:
+
+- **`/skill-creator`** — The #1 most-upvoted recommendation (8 points). A built-in skill that lets Hermes create new skills dynamically. Community consensus: "start here, let Hermes build what you need."
+- **humanizer** — Built-in skill that makes AI-generated text more natural. Frequently used by content creators.
+- **github-pr-workflow / github-repo-management** — Built-in skills for GitHub automation. Used by developers running CI/CD through Hermes.
+- **Weather** — Simple but cited as surprisingly useful: "I use it all the time, surprisingly." Good example of a skill that earns its keep through frequency.
+- **blog-publisher** — Custom community skill for automated blog publishing workflows.
+- **grill with docs** — Custom skill for interrogating/querying documentation sources.
+- **computer-use** — Desktop control skill (macOS background driving).
+- **obsidian / apple-notes / notion** — Knowledge management skills, with Obsidian being the community favorite.
+
+**Community philosophy on skills:** The most-upvoted takeaway from the thread — "The ones you need to achieve your daily goals or tasks, no more, no less." Start minimal; add only what earns its context budget.
+
+### Building Your Own Skills
+
+Key community patterns:
+1. **Start simple:** A single SKILL.md with frontmatter + markdown body. Use `/skill-creator` to scaffold.
+2. **Let Hermes iterate:** Describe what you want; the agent generates a skill and improves it through use.
+3. **Audit regularly:** Skills can drift. The "Hermes Skill Audit" workshop (Jun 7) covers why skills stop firing and how to fix them — stale trigger conditions, path assumptions that changed, model-switching side effects.
+4. **Share selectively:** Not every skill needs to be shared. Polish the ones that solve real problems.
+
+### Skill Packs & Multi-Skill Bundles
+
+A community member built and shared 7 ready-to-install skill/plugin packs (May 30) covering:
+- **Auto-install skill** — A meta-skill that installs other skills programmatically
+- **Productivity bundle** — Task management, scheduling, note-taking grouped skills
+- **Development tools** — Git workflow, code review, project management skills
+- Additional packs for content creation, automation, and system monitoring
+
+The auto-install pattern is notable: it reduces the friction of "find, download, configure" to a single command, making skill discovery and adoption faster.
+
+### Known Issues
+
+- **Skill curator:** Community previously reported that the skill curator feature had issues with stale metadata. **Partially addressed in v0.17.0 (Jun 19):** The curator now prunes stale skills by default but no longer runs its LLM-powered consolidation pass unless opted in (`curator_consolidate: true`), eliminating aux-model spend on routine runs. [thread: "The skill curator feature in Hermes Agent has a big issue", May 11](https://www.reddit.com/r/hermesagent/comments/1t9smfc/)
+- **Skills not firing:** Common causes: trigger wording mismatch, path assumptions broken after env changes, model switches that drop skill context. Audit workflow: check frontmatter triggers → verify file paths → test with small prompt.
+- **Skill review:** Some users report skill review/approval delays or unclear status. [thread: "Skill review issue!", May 8](https://www.reddit.com/r/hermesagent/comments/1t71x8c/)
+
+---
+
+## Part 6: API Connections, Webhooks & Automation Patterns
+
+### Authentication Patterns
+
+The community has settled on three main approaches:
+
+1. **API keys in `.env`:** Store in `~/.hermes/.env`, reference in config as `${VAR}`. Better than plaintext in config.yaml but still plaintext on disk.
+2. **MCP with OAuth:** For supported providers (Linear, Sentry, Stripe, etc.), MCP's built-in OAuth 2.1 flow handles token exchange, refresh, and secure caching at `~/.hermes/mcp-tokens/`.
+3. **Local password manager + MCP server:** Community-built solution that wraps a local password manager (e.g., Bitwarden CLI, `pass`) in an MCP server so Hermes retrieves secrets at runtime without storing them in plaintext. [thread: "Stop putting API keys in plaintext for Hermes", May 11](https://www.reddit.com/r/hermesagent/comments/1tabisq/)
+
+### Webhook Patterns
+
+- **GitHub → Hermes:** Webhook receives PR events → Hermes reviews code, posts comments back via GitHub API.
+- **Stripe → Hermes:** Payment events → agent logs transactions, sends alerts.
+- **Custom webhooks:** Any service that can POST JSON can trigger Hermes. HMAC signature validation prevents spoofing.
+
+### Cron + API = Automation
+
+The most common automation pattern is cron job + API call:
+1. Cron job fires on schedule
+2. Hermes calls external API (weather, stocks, calendar, GitHub, etc.)
+3. Agent processes data and posts summary to Telegram/Discord
+
+### n8n Integration
+
+n8n (visual workflow automation) + Hermes is a growing pattern:
+- n8n handles the workflow graph and triggers
+- Hermes provides the intelligence layer (decisions, natural language, tool selection)
+- MCP bridges them
+
+### Browser Automation
+
+- **Browserbase web skill library:** A community member built a web skill library for advanced browser automation, gaining traction. [thread: "Have you tried this new web skill library by Browserbase?", Jun 10](https://www.reddit.com/r/hermesagent/comments/1u2fyuq/)
+- **Built-in browser tools:** Hermes ships with browser_navigate, browser_click, browser_snapshot, browser_console, etc.
+
+---
+
+## Part 7: Authentication & Security for Integrations
+
+### API Key Management — The Credential Problem
+
+The "Stop putting API keys in plaintext" thread (May 11, 23 comments) surfaced the community's best thinking on this problem. Three main solutions emerged:
+
+**OpenPass** (MIT license, community-built)
+- CLI-first password manager with native MCP server
+- Agent requests credentials via MCP → human approves (TouchID/Windows Hello) → session caches in OS keyring (15-min default)
+- Uses `age` (X25519) encryption — no GPG complexity
+- Git-synced vault, imports from 1Password/Bitwarden
+- Trade-off: credentials do reach the agent (with permission), meaning they can appear in chat logs/model APIs
+
+**Agent Vault** (Infisical, mixed license)
+- Proxy-based credential brokering — agents NEVER touch raw credentials
+- One command: `agent-vault run -- hermes` scaffolds everything
+- Credentials injected at the proxy layer; agent only sees proxy tokens
+- Trade-off: needs running server process, CA cert in every agent env, `ee` directory with premium enterprise features
+- Community feedback: "agents get tripped up by the proxy" but improving rapidly
+
+**UnifyKeys** (proxy token model)
+- Store provider keys in encrypted vault, get a proxy token
+- App only sees the proxy token — never the real key
+- Usage tracking per API/provider, IP visibility, revoke/block suspicious traffic
+- Free GitHub key scanner for exposed credentials
+
+**Community consensus on credential security (ranked):**
+
+1. **MCP OAuth** — Best option where supported. No secrets on disk. Supported for Linear, Sentry, Stripe, Atlassian, Asana, Figma.
+2. **Agent Vault / credential brokering** — Best architectural guarantee. Agents never hold real credentials even in memory. Worth the setup complexity for production use.
+3. **OpenPass / password manager + MCP** — Good balance. Secrets retrieved at runtime with human approval. Simpler than Agent Vault but credentials enter agent context.
+4. **UnifyKeys proxy token** — Good for LLM provider keys specifically. Simpler than full MCP setup.
+5. **`~/.hermes/.env` with restrictive permissions** — Acceptable minimum. `chmod 600`. Better than config.yaml but still plaintext on disk.
+6. **Plaintext in config.yaml** — Avoid. Multiple threads warn against this.
+
+**The core tension:** Convenience (secrets available when the agent needs them) vs exfiltration prevention (secrets never in agent memory, chat logs, or model APIs). Agent Vault represents the exfiltration-prevention extreme; OpenPass the convenience extreme. The right answer depends on your threat model.
+
+**Fresh discussion — today (Jun 28, 2026):** A thread asking "Credential management: what's the state of the art on Hermes?" confirms this is an active concern. The OP specifically worried about agents retrieving credentials and passing them back via prompt injection. Community responses: Infisical/Agent Vault recommended as the credential-brokering solution; a new tool "taOS" with agent-specific access keys also mentioned. The consensus: credential brokering (agents never see real secrets) is the direction the community is heading. [thread: "Credential management: what's the state of the art on Hermes?", 6 upvotes, 5 comments, Jun 28](https://www.reddit.com/r/hermesagent/comments/1ui3137/)
+
+### Sandbox Considerations
+
+- **Docker:** Running Hermes in a container limits filesystem access but complicates tool access (file paths, local services).
+- **VM isolation:** Some users run Hermes in a dedicated VM for complete separation. [thread: "Security & Paranoia & Fun", Jun 14](https://www.reddit.com/r/hermesagent/comments/1u5cqb6/)
+- **VPS:** Cloud VPS provides network isolation from your home network. Still requires firewall hardening. [thread: "Is VPS option good for privacy & security?", Jun 12](https://www.reddit.com/r/hermesagent/comments/1u492zr/)
+
+### Permission Prompts
+
+Hermes's safety layer may flag and require confirmation for:
+- Financial files (spreadsheets with expense data)
+- Destructive operations (file deletion, directory removal)
+- External API calls to new domains
+
+This is configurable but defaults to safe. The community generally recommends keeping safety prompts enabled for integrations that touch sensitive data.
+
+---
+
+## Part 8: FAQ
+
+1. **Which messaging platform should I start with?** Telegram. Best-documented, most community support, simplest setup.
+
+2. **Can I use multiple messaging platforms at once?** Yes — the gateway handles routing. Same agent, same memory, different frontends.
+
+3. **Will Google ban my Gmail if Hermes uses it?** Very likely for free Gmail accounts. Use Google Workspace (paid) or a dedicated email provider.
+
+4. **Obsidian or Notion for my knowledge base?** Obsidian — local files, no API rate limits, better Hermes compatibility. Notion if you need collaboration features.
+
+5. **How do I connect Hermes to Home Assistant?** Install the community HA add-on (5-minute setup). Use Hermes as the intelligence layer, HA for device control.
+
+6. **What's the safest way to store API keys?** MCP OAuth where supported. Otherwise, a local password manager wrapped in an MCP server.
+
+7. **How do I find quality skills in the 90K+ Skills Hub?** Check subreddit recommendations, sort by recent installs, review author reputation. Prefer skills updated in the last 3 months.
+
+8. **Can Hermes create its own skills?** Yes — it can self-evolve skills based on experience. The skill-audit workflow (review → patch → test) refines them.
+
+9. **What's the difference between a skill and an MCP server?** Skills are Hermes-specific (markdown instructions + optional scripts). MCP servers are external tool servers using the Model Context Protocol standard — language-agnostic and reusable across MCP-compatible clients.
+
+10. **How do I trigger Hermes from external services?** Webhooks adapter receives POST requests, validates signatures, and routes to the agent. Cron jobs for scheduled triggers.
+
+11. **Can Hermes browse the web automatically?** Yes — built-in browser tools (browser_navigate, browser_click, etc.) plus external libraries like Browserbase's web skill library.
+
+12. **What's the best OAuth setup for cloud APIs?** Use MCP's built-in OAuth 2.1 support. For remote/VPS hosts, use the paste-back flow (copy redirect URL from browser).
+
+---
+
+## Part 9: Knowledge Table — Every Integration, Tool & Plugin
+
+| Integration | Category | Type | Setup Difficulty | Free Tier | Best For | Watch For |
+|------------|----------|------|-----------------|-----------|----------|-----------|
+| Telegram Gateway | Messaging | Native | Easy | Free | Primary chat interface | Message formatting quirks |
+| Discord Gateway | Messaging | Native | Easy | Free | Community bots | — |
+| WhatsApp Gateway | Messaging | Native | Medium | Free | Mobile-first users | Setup more involved |
+| Signal Gateway | Messaging | Native | Medium | Free | Privacy-focused | — |
+| Email Gateway | Messaging | Native | Medium | Free (bring provider) | Async communication | Gmail bans bot activity |
+| Himalaya CLI | Email | Skill | Easy | Free (OSS) | IMAP/SMTP agent email | Terminal-only |
+| Obsidian Skill | Knowledge | Skill | Easy | Free (OSS) | Local knowledge base | Vault must be accessible |
+| Notion API | Knowledge | Skill | Medium | Free (limited API) | Collaborative knowledge | API rate limits |
+| Google Calendar | Productivity | Skill (gws CLI) | Medium | Free | Scheduling/reminders | Gmail account risk |
+| Gmail (via gws) | Productivity | Skill (gws CLI) | Medium | Free (personal) | Agent email | Ban risk on free accounts |
+| Apple Notes (memo) | Productivity | Skill (CLI) | Easy | Free (macOS) | Quick notes | Occasional skill issues |
+| Apple Reminders | Productivity | Skill (CLI) | Easy | Free (macOS) | Task management | macOS-only |
+| iMessage | Messaging | Photon Spectrum plugin | Easy | Free (Photon managed line) | SMS/iMessage, all platforms | New in v0.17.0 — no Mac required |
+| SimpleX | Messaging | Bundled plugin | Easy | Free (OSS) | Privacy-first messaging | New in v0.17.0 |
+| WhatsApp Business Cloud | Messaging | Native adapter | Easy | Paid (Meta) | Official WhatsApp API | New in v0.17.0 — no bridge process |
+| Home Assistant | Home Automation | Community Add-on | Easy | Free (OSS) | Smart home control | Can't edit automations directly |
+| MQTT | IoT | Protocol | Medium | Free | Sensor data | Requires broker setup |
+| MCP Catalog | Developer | Native | Easy | Free | One-click tool installs | Read manifest carefully |
+| GitHub MCP | Developer | MCP Server | Easy | Free | Code/issue management | PAT required |
+| n8n | Automation | External + MCP | Medium | Free (self-hosted) | Visual workflows | Adds infrastructure |
+| Webhooks Adapter | Developer | Native | Medium | Free | External triggers | Requires public endpoint |
+| Browserbase Skill | Browser | External Skill | Medium | Free tier available | Advanced web automation | External dependency |
+| xurl CLI | Social | Skill (CLI) | Medium | Free (X API) | X/Twitter integration | API access required |
+| Shopify MCP | E-commerce | Community MCP | Medium | Paid (Shopify) | Store management | Community-maintained |
+| Amazon MCP | E-commerce | Community MCP | Medium | Paid (AWS) | Product intelligence | Community-maintained |
+| Bitwarden MCP | Security | Community MCP | Medium | Free (OSS) | Secret management | Setup involves local server |
+| Todoist | Productivity | API | Medium | Free tier | Task management | API integration custom |
+| Excel/Sheets | Productivity | Native | Easy | Free | Spreadsheet data | Safety prompts on financial data |
+
+---
+
+## Part 10: Sources & Contribute
+
+This megathread is built from ~42 community threads, X/Twitter posts, and official Hermes docs from late April – June 28, 2026. Updated against v0.17.0 release notes (June 19, 2026). Key sources include:
+
+- r/hermesagent subreddit discussions
+- X/Twitter: @NousResearch, @WolframRvnwlf, community builders
+- Official Hermes Agent docs (hermes-agent.nousresearch.com)
+- GitHub: NousResearch/hermes-agent, Skills Hub
+
+**Something missing? Wrong?** Reply with corrections, additions, or your own integration setup. Community megathreads improve through contribution.
+
+**See also:**
+- [Models, Providers & Plans Megathread](https://www.reddit.com/r/hermesagent/comments/1ufrtsf/) — for model selection and cloud provider comparisons
+- [Multi-Agent & Profiles Megathread](https://www.reddit.com/r/hermesagent/comments/1ucmvi8/) — for running multiple agents and profiles
+- [Kanban Setups Megathread](https://www.reddit.com/r/hermesagent/comments/1ugkihk/) — for task orchestration and Kanban boards
+- [Cost & Token Optimization Megathread](https://www.reddit.com/r/hermesagent/comments/1ud03si/) — for keeping costs under control
+
+---
+
+## Comment-Sourced Updates
+
+- **Matrix omission:** commenters flagged Matrix as missing from the messaging survey. Matrix is retained as a community-requested integration, not represented here as officially supported until current Hermes documentation confirms the support path.
+
+- **Credential boundaries:** avoid reusing one provider credential across unrelated agents and services when scoped, revocable credentials are available. Third-party credential-broker products mentioned in comments remain unverified examples.
+
+- **Plugin maturity:** local-knowledge, memory, Home Assistant, and enterprise-integration projects mentioned in comments must be checked for maintenance, compatibility, and disclosure before recommendation. Vendor promotional claims are archived rather than endorsed.
+
+## Maintaining this guide
+
+Open an issue or pull request with the official source, date checked, Hermes/backend version, and enough reproduction detail to evaluate the change. No referral links, affiliate links, or unsupported promotional claims.

--- a/megathreads/kanban-setups-2026-06.md
+++ b/megathreads/kanban-setups-2026-06.md
@@ -1,0 +1,721 @@
+# Kanban Setups Megathread — Hermes Agent (June 2026)
+
+> Community-maintained GitHub version of the Reddit megathread.
+>
+> Original Reddit thread: https://www.reddit.com/r/hermesagent/comments/1ugkihk/kanban_setups_megathread_hermes_agent_june_2026/
+>
+> **Snapshot:** Original post preserved and normalized; comment corrections reviewed through July 16, 2026.
+>
+> Time-sensitive prices, quotas, versions, model availability, benchmarks, and third-party project claims remain dated snapshots unless an official source is cited.
+
+---
+
+**Original post last updated:** June 26, 2026
+**Sources used by the original post:** Official Hermes Kanban documentation, the Kanban tutorial, the kanban-orchestrator skill, 15+ r/hermesagent threads, Nous Research/community posts, release notes through v0.17, external guides, and the earlier multi-agent megathread.
+
+---
+
+## TL;DR — Quick Reference
+
+| Decision | Pick | Why |
+|----------|------|-----|
+| First-time Kanban setup | **Hermes' built-in Kanban** (zero-config) | Ships with every install — `hermes kanban init` |
+| Starting profiles | **Orchestrator + 1 specialist** | You don't need 5 profiles on day one |
+| Kanban vs delegate_task | **Kanban for durable work** | Survives crashes, has human-in-loop, audit trail |
+| Best Kanban model | **Same as your daily driver** (auxiliary decomposer can be smaller) | Kanban workers use the assigned profile's model |
+| Board isolation | **One board per project** | Only needed when workstreams collide |
+| SOUL.md strategy | **One per profile** | Define role, not behavior — let the dispatcher orchestrate |
+| Config trap #1 | **`failure_limit` too low** | Default 2 — bump to 5 if workers crash on first attempt |
+| Config trap #2 | **No `HERMES_KANBAN_TASK` env check** | Workers can't see their task without it |
+| Dashboard | `hermes dashboard` → Kanban tab | Live WebSocket updates, drag-drop, drawer |
+
+---
+
+## Part 1: What Is Kanban (and Why It's Different)
+
+Kanban is a **durable SQLite-backed task board** shared across all your Hermes profiles. Not a RPC call like `delegate_task` — it's a persistent message queue where every handoff is a row anyone can see and edit.
+
+### The key distinction
+
+| Aspect | `delegate_task` | Kanban |
+|---|---|---|
+| Shape | RPC call (fork → join) | Durable message queue + state machine |
+| Parent | Blocks until child returns | Fire-and-forget after `create` |
+| Child identity | Anonymous subagent | Named profile with persistent memory |
+| Resumability | None — failed = failed | Block → unblock → re-run; crash → reclaim |
+| Human in the loop | Not supported | Comment / unblock at any point |
+| Agents per task | One call = one subagent | N agents over task's life (retry, review, follow-up) |
+| Audit trail | Lost on context compression | Durable rows in SQLite forever |
+| Coordination | Hierarchical (caller → callee) | Peer — any profile reads/writes any task |
+
+**Use `delegate_task` when:** parent agent needs a short reasoning answer, no humans involved, result goes back into parent's context.
+**Use Kanban when:** work crosses agent boundaries, needs to survive restarts, might need human input, or you want a discoverable audit trail.
+
+### How it works at a glance
+
+```
+You create a task → dispatcher polls → spawns assigned profile as worker
+    → worker calls kanban_show(), does work, calls kanban_complete()
+    → child tasks auto-promote from todo → ready when parents finish
+    → next worker picks up ready task → repeat
+```
+
+Three surfaces, one `kanban.db`:
+- **Workers** drive the board through `kanban_*` tools (`kanban_show`, `kanban_complete`, `kanban_block`, `kanban_heartbeat`, `kanban_comment`, `kanban_create`, `kanban_link`)
+- **You** drive it through `hermes kanban …` CLI or `/kanban …` slash command
+- **Dashboard** drives it through drag-drop and inline forms
+
+---
+
+## Part 2: Profiles — Your Kanban Team
+
+Kanban is built on profiles. Every task gets an `--assignee <profile>`, and the dispatcher spawns that profile as a worker.
+
+### Recommended minimum setup
+
+```
+Profile: default (orchestrator)
+  Role: Routes work, creates tasks, doesn't do the work itself
+  Toolsets: kanban, gateway, memory (no terminal/file)
+  Model: Your strongest reasoning model
+  SOUL.md: Orchestrator routing instructions
+
+Profile: worker (specialist)
+  Role: Implements, researches, writes, reviews
+  Toolsets: terminal, file, web (whatever the work needs)
+  Model: Works well with tools
+  SOUL.md: "You are a [role]. When spawned as a kanban worker..."
+```
+
+### The orchestrator role
+
+The orchestrator is a profile that **decomposes goals into tasks and routes them** but does not do the work itself. The official docs call this out explicitly:
+
+> "A well-behaved orchestrator does not do the work itself. It decomposes the user's goal into tasks, links them, assigns each to one of the profiles you've set up, and steps back."
+
+The official kanban-orchestrator guidance (auto-injected) includes:
+- Anti-temptation rules ("Do not execute the work yourself")
+- Step 0: discover available profiles before planning
+- Decomposition playbook: sketch task graph → create cards with dependencies → link → complete
+
+**Which profile owns decomposition?** Controlled by `kanban.orchestrator_profile` in config. If unset, falls back to the active default profile.
+
+### Profile descriptions matter
+
+The decomposer reads profile descriptions to route work. Set them:
+
+```bash
+hermes profile describe researcher --text "Web research, document analysis, API exploration"
+hermes profile describe coder --text "Python, JavaScript, system scripts, refactoring"
+hermes profile describe researcher --auto   # LLM generates from installed skills
+```
+
+Without descriptions, the decomposer can still route by profile name but less precisely. If it picks an unknown profile name, the child routes to `kanban.default_assignee` (or the active default).
+
+### Profile Builder (v0.16+)
+
+Since v0.16 (June 2026), you can build complete profiles visually in the dashboard:
+
+1. Open `hermes dashboard` → Profiles section
+2. Click "New Profile" — name, description, model, SOUL.md, toolsets, enabled skills
+3. The dashboard generates the profile directory and config.yaml automatically
+4. Profile descriptions are also editable in the dashboard (the decomposer reads them)
+
+No more `hermes profile create --clone` and manual config edits for basic setups. The dashboard also shows all profiles with their assigned Kanban task counts per profile.
+
+### Common profile rosters from the community
+
+**The 2-profile starter:**
+- `default` (orchestrator — routes, never implements)
+- `worker` (does everything)
+
+**The 3-profile standard:**
+- `orchestrator` (routes, decomposes)
+- `researcher` (web research, data gathering)
+- `implementer` (coding, writing, execution)
+
+**The 5-profile fleet:**
+- `orchestrator`
+- `researcher`
+- `coder`
+- `writer`
+- `reviewer`
+
+⚠️ **Don't build the org chart on day one.** Start with 2 profiles. Add specialists only when you actually hit context pollution or routing confusion. Most users never need more than 4 profiles.
+
+---
+
+## Part 3: SOUL.md Configuration for Kanban
+
+Each profile in your Kanban team needs a SOUL.md that defines its role in the board workflow. Here's the difference between an orchestrator SOUL.md and a worker SOUL.md.
+
+### Orchestrator SOUL.md (the router)
+
+```yaml
+# ~/.hermes/profiles/default/SOUL.md
+personality: Orchestrator / routing agent
+tone: Professional, clear, efficient
+---
+You are the Kanban orchestrator. Your job is to decompose the user's goals into tasks, assign them to specialist profiles via the kanban board, and report back. You do NOT do the work yourself.
+
+## Rules
+1. When the user asks for anything, first decide: is this a quick answer I can give directly, or does it need specialist work?
+2. If it needs specialist work, break it into parallel tasks where possible. Use kanban_create with assignee, title, body, and optional parents.
+3. Assign to profiles that actually exist. Run `hermes profiles list` if unsure.
+4. After creating tasks, tell the user what you queued and who's assigned.
+5. Do not implement. Do not research. Do not write code. Route only.
+
+## Available specialist profiles
+- `researcher` — web research, API docs, data gathering
+- `coder` — Python, JS, system scripts, GitHub
+- `writer` — drafting, editing, prose
+- `reviewer` — code review, quality checks
+```
+
+### Worker SOUL.md (the implementer)
+
+```yaml
+# ~/.hermes/profiles/worker/SOUL.md (for a generalist worker)
+personality: Task executor
+tone: Practical, direct
+---
+You are a kanban worker. When spawned for a task, follow this lifecycle:
+
+1. Call kanban_show() to read your task's title, body, and parent handoffs.
+2. Change to $HERMES_KANBAN_WORKSPACE directory.
+3. Do the work: research, code, write, whatever the task requires.
+4. Call kanban_heartbeat(note="...") during long operations (at least once/hour).
+5. Complete with kanban_complete(summary="...", metadata={...}).
+
+## Handoff quality
+- summary: human-readable closeout
+- metadata: machine-readable handoff (changed_files, verification, residual_risk)
+- If stuck, call kanban_block(reason="...") instead of completing
+```
+
+### Community SOUL.md patterns
+
+- **"Split personality" pattern** (u/Starrwulfe): One profile, multiple personalities via skill files, routed by constitution.md. Collapses 5 agents into 1.
+- **"Strict role enforcement"** (u/rk1213): Each profile gets explicit role boundaries — "You are ONLY a researcher/coder/reviewer. Never step outside your role."
+- **"Temperature as parameter"** (multiple users): Lower temp (0.3-0.5) for workers (predictable tool use), higher (0.7-1.0) for orchestrators (creative decomposition).
+- **Model-specific SOUL.md notes:** Users running local models often add disclaimers like "You run on Qwen3-27B at Q4_K_M. You have 32K context. Work within these constraints."
+
+---
+
+## Part 4: Config.yaml — The Kanban Section
+
+All Kanban config lives under `kanban:` in `~/.hermes/config.yaml`:
+
+```yaml
+kanban:
+  # Dispatcher
+  dispatch_in_gateway: true          # runs inside gateway process (default)
+  dispatch_interval_seconds: 60      # poll interval (default)
+  dispatch_stale_timeout_seconds: 14400  # 4h before reclaiming stale workers
+  failure_limit: 2                   # circuit breaker trips after N failures
+
+  # Concurrency
+  max_in_progress: ~                  # unset = unlimited (default)
+  max_in_progress_per_profile: ~      # per-profile cap (default = unlimited)
+
+  # Triage / decomposition
+  auto_decompose: true                # dispatcher auto-runs decomposer (default)
+  auto_decompose_per_tick: 3          # max decompositions per tick
+  auto_promote_children: true        # auto-promote decomposed children to ready
+  orchestrator_profile: ""            # profile for root orchestration task
+  default_assignee: ""                # fallback when LLM picks unknown profile
+  default_workdir: ~                  # board-level default workspace dir
+
+  # Subscriptions
+  auto_subscribe_on_create: true      # auto-subscribe origin to task events
+```
+
+### Tuning advice from the community
+
+- **`failure_limit`:** Default 2 is aggressive. If your workers use local models that occasionally crash on first attempt (OOM, segfault), bump to 5. The circuit breaker is a safety net, not a quality gate.
+- **`dispatch_interval_seconds`:** 60s is fine for most. Drop to 10-15s if you want snappy response for short tasks. Keep at 60s+ if workers take minutes (local LLM, slow API).
+- **`max_in_progress`:** Critical for local-model setups. If you're running a 7B model on a laptop, cap to 1-2 so you don't OOM. Unset = unlimited.
+- **`auto_decompose`:** Great for the "drop a one-liner, walk away" flow. Turn off if you want full manual control — triage tasks sit in triage until you hit the ⚗ Decompose button.
+- **`auto_promote_children: false`:** Use if you want to review decomposed tasks before they get picked up. Children stay in `todo` until you promote them.
+
+### Auxiliary LLM slots
+
+```yaml
+auxiliary:
+  kanban_decomposer:
+    model: anthropic/claude-sonnet-4    # or local model
+    provider: anthropic
+  profile_describer:
+    model: custom:lmstudio/gemma-4-12b-it  # lightweight model for this
+```
+
+- `kanban_decomposer`: Model that produces the task graph. Can be a different/smaller model than your main chat model. Set it if your main model is slow or expensive for decomposition calls.
+- `profile_describer`: Model that auto-generates profile descriptions (`hermes profile describe --auto`). A small local model is fine here.
+
+---
+
+## Part 5: Models for Kanban Workers
+
+The model choice per profile dramatically affects Kanban performance.
+
+### Guidelines
+
+| Worker type | Recommended model | Why |
+|---|---|---|
+| Orchestrator | Strong reasoning (DeepSeek V4, Claude Sonnet 4, Qwen3-27B) | Decomposition quality depends on task understanding |
+| Researcher | Strong web-reading, medium size | Cost efficiency; doesn't need top reasoning |
+| Coder | Local Qwen3-27B or Qwen3.5-9B | Tool-calling reliability matters |
+| Writer/translator | Small local (Gemma-4-12B, Qwen3.5-9B) | These are serialization tasks |
+| Reviewer | Same as coder but different SOUL.md | Needs same model quality for correctness |
+
+### Known issues
+
+- **Local model workers on slow GPUs:** Workers time out before finishing. Fix: set `max_in_progress: 1` so only one worker runs at a time, and raise `dispatch_stale_timeout_seconds`.
+- **Cloud model costs burn fast:** Each dispatcher spawn creates a new session. A task that takes 20 turns of Claude costs $0.60-1.20 per run. Use local models for high-volume workers.
+- **Model switching per profile:** Each profile has its own model config. You can route a task to a profile running DeepSeek and another to a profile running a local Qwen3 — within the same Kanban board.
+
+### Context window considerations
+
+- Workers inherit the profile's config, including context window settings.
+- Kanban adds overhead via `kanban_show()` output (task title, body, parent handoffs, prior attempts, comments). For tasks with long comment threads or many prior attempts, the context payload can be 2-8K tokens.
+- **Goal-mode cards** (`--goal`) add per-turn judge overhead: the auxiliary model evaluates completion after every turn. Budget accordingly.
+
+---
+
+## Part 6: Tools and Skills for Kanban Workers
+
+### Built-in kanban toolset
+
+Every dispatcher-spawned worker automatically gets these tools. No manual configuration required — `HERMES_KANBAN_TASK` env var flips them on:
+
+| Tool | Purpose |
+|---|---|
+| `kanban_show` | Read current task (title, body, parent handoffs, comments, prior attempts) |
+| `kanban_list` | List tasks by assignee/status/tenant (orchestrators) |
+| `kanban_complete` | Finish task with summary + metadata |
+| `kanban_block` | Stop work with a reason + block kind |
+| `kanban_heartbeat` | Liveness signal during long ops |
+| `kanban_comment` | Append durable note to task thread |
+| `kanban_create` | (Orchestrators) Fan out into child tasks |
+| `kanban_link` | (Orchestrators) Add dependency edge |
+| `kanban_unblock` | (Orchestrators) Move blocked task back to ready |
+
+### Pin extra skills per task
+
+You can attach skills to individual tasks without editing the profile:
+
+```bash
+hermes kanban create "Translate README to JP" \
+    --assignee linguist --skill translation
+
+hermes kanban create "Audit auth flow" \
+    --assignee reviewer --skill security-pr-audit --skill github-code-review
+```
+
+Workers get these skills loaded on top of their profile's defaults. Great for one-off specialist tasks without profile bloat.
+
+### What not to give a kanban worker
+
+- **Don't give orchestrators terminal/file tools** — they'll start implementing instead of routing. Restrict to `kanban`, `gateway`, `memory`.
+- **Don't overload workers with irrelevant skills** — each skill increases startup time and context overhead. Keep worker profiles lean (15-20 skills maximum per the community's gradual-approach advice).
+
+---
+
+## Part 7: Configuration Parameters — Full Reference
+
+### CLI create flags
+
+```bash
+hermes kanban create "<title>" \
+    --body "..."                    # Task description
+    --assignee <profile>            # Who does this work
+    --parent <id>                   # Dependency (repeat for multiple)
+    --tenant <name>                 # Namespace for multi-business setups
+    --workspace scratch|worktree|dir:<path>  # Working directory type
+    --branch <name>                 # Git branch for worktree workspaces
+    --priority N                    # 1-5 (higher = more important)
+    --triage                        # Park in triage column first
+    --idempotency-key KEY           # Dedup for cron/automation
+    --max-runtime 30m|2h|1d         # Hard timeout per run
+    --max-retries N                 # Circuit breaker threshold (overrides failure_limit)
+    --goal                          # Goal-mode (judge evaluates completion)
+    --goal-max-turns N              # Max turns in goal mode (default 20)
+    --skill <name>                  # Pin skill to this task (repeat for multiple)
+```
+
+### Key config knobs
+
+| Config key | Default | What it does |
+|---|---|---|
+| `kanban.dispatch_interval_seconds` | 60 | How often dispatcher polls for ready tasks |
+| `kanban.dispatch_stale_timeout_seconds` | 14400 (4h) | Reclaim workers with no recent heartbeat |
+| `kanban.failure_limit` | 2 | Circuit breaker trips after N consecutive failures |
+| `kanban.max_in_progress` | unset (unlimited) | Board-wide concurrency cap |
+| `kanban.max_in_progress_per_profile` | unset (unlimited) | Per-profile concurrency cap |
+| `kanban.auto_decompose` | true | Auto-run decomposer on triage tasks |
+| `kanban.auto_decompose_per_tick` | 3 | Max decompositions per dispatcher tick |
+| `kanban.auto_promote_children` | true | Auto-promote decomposed children to ready |
+| `kanban.orchestrator_profile` | "" | Profile for root orchestration task (empty = active default) |
+| `kanban.default_assignee` | "" | Fallback assignee for unknown profile names |
+| `kanban.default_workdir` | unset | Board-level default workspace directory |
+| `auxiliary.kanban_decomposer` | same as main | Model for task decomposition |
+| `auxiliary.triage_specifier` | same as main | Model for triage → todo spec writing |
+| `auxiliary.profile_describer` | same as main | Model for auto-generated profile descriptions |
+
+---
+
+## Part 8: Community Setups and Patterns
+
+### The 6-Profile Production Pipeline (u/rk1213)
+
+One of the most detailed community setups posted — a self-governing pipeline for overnight coding work:
+
+> **"there's two main purposes for the kanban for me: 1) guardrails and checks. I always have a profile that reviews/audits work using a different model family. 2) automation. I give the team a job and I can still use my agent as normal. I can give the team a full coding job before I sleep and then wake up with the job completed."**
+
+The 6 profiles:
+1. **orchestrator** — handles routing tasks to the right agent
+2. **research/analyst** — searches for relevant information (tools, APIs, example workflows)
+3. **planner** — writes implementation plans with a template, incorporates research
+4. **plan reviewer** — first guardrail; reviews the plan, checks for hallucinations
+5. **coder** — implements based on the approved plan
+6. **code reviewer** — second guardrail; checks for errors, runs tests
+
+> "The whole kanban pipeline circulates until task is completed. I have a watcher that notifies me if there is anything that specifically needs my approval or input. If none, the whole end to end process is pretty much self governing."
+
+Pipeline output example from an overnight run:
+
+```
+✅ Orchestrator decomposed Phase 2
+✅ Research analyst gathered codebase context
+✅ Planner wrote the implementation plan
+✅ Plan reviewer reviewed it
+✅ Orchestrator routed the review
+🔄 Planner is now fixing the plan (Revision 1) — reviewer had feedback
+⏳ Plan re-review queued
+⏳ Orchestrator acceptance queued
+```
+
+> "So far, I won't say it can complete everything without errors or gets everything 100% the way I want it every time, but it's about 70-80% there."
+
+**Key insight:** "By default, these agents won't have access to the skills/toolsets that you have built for your main agent. You will need to give these agents relevant skills and toolsets that they require in order to function properly."
+
+### The Two-Specialist Starter (u/itsdodobitch, mod)
+
+The top-voted comment in the recent Kanban discussion thread (+16) explains the fundamental difference:
+
+> "Profiles are not just about personality. A profile defines what your agent knows, what it remembers, which tools it has access to, which skills it can use (and automatically edit), and its memory. Each profile has its own set of files because a profile is literally a nested folder that mirrors the default structure."
+
+Recommended starter split:
+- One profile with only terminal and file operations
+- Another with web and browser access for research
+
+> "With Kanban, your agent can create a task, including one much larger and more complex than what you would usually assign to a delegate-task sub-agent, and assign it to a specific profile. A dispatcher then checks every 60 seconds for pending Kanban tasks and moves the board accordingly."
+
+### The Visual-LLM Split (u/H4llifax)
+
+> "I'm using a text-only model as my main model, and I have a VLM as second profile for vision related tasks. It's a bit awkward that delegate_task can't delegate to other profiles."
+
+This is a concrete use case where Kanban uniquely solves a problem: when your main model is text-only, Kanban lets you route vision tasks to a profile with a vision model — something `delegate_task` can't do.
+
+### The 46-Profile Fleet (u/Bulky_Magician)
+
+> "I have 3 separate workflows with routing profiles for each. Overall I think I have 46 profiles right now. It's worked out very well but I do feel like I need to become stricter on routing profiles remembering all use cases for downstream profiles."
+
+⚠️ **Counterpoint from the same user:** "Despite putting time and effort into setting it up, I've just not been able to get into using kanban or even really cron jobs. I don't have a frontier model, just owl alpha, and so far I feel like I need to babysit it."
+
+This is a recurring theme — Kanban with weaker local models requires more tuning and tolerance for imperfect automation.
+
+### From X/Twitter and Hermes Release Notes
+
+**Nous Research Kanban announcement** (May 3, 2026, v0.12.0 launch) — the official announcement post on X hit:
+- **1.5M views, 5.9K likes, 492 reposts, 270 replies**
+- Describes Kanban as: "Agents claim tasks from a board, work in parallel, and hand off when blocked. You watch progress and unblock from one easy view instead of juggling terminals."
+- The 270 replies contain user setups, questions, and tuning advice beyond what's captured in this megathread
+
+**v0.15 "Velocity" Release (May 28-29, 2026):**
+- "Kanban and multi-agent work got more serious" — continued platform push toward durable multi-agent task graphs with workers, verifiers, and swarms
+- v0.15.1 fixed **Kanban worker SIGTERM handling** — previously, sending SIGTERM to a worker could orphan the task in the database; patch adds a graceful cancel with failure reason code
+- "stronger Kanban orchestration" listed as upgrade reason
+- Core `run_agent.py` refactored from 16K to 4K lines for safer future changes
+
+**v0.16 "Surface" Release (June 8, 2026):**
+- **Profile Builder** in the dashboard — build complete profiles visually (SOUL.md, tools, skills, model) without touching config files — @shannholmberg on X
+- Dashboard expanded for MCP catalog, channels, credentials, webhooks, memory
+- Remote backend support (desktop connects to VPS gateway)
+- Model picker improvements across all surfaces
+
+**v0.17 "The Reach Release" (June 19, 2026):**
+- **Background subagents** — directly impacts Kanban workers; subagents can now run as detached background processes
+- iMessage and WhatsApp integrations via Photon Spectrum
+- ~1,475 commits, ~800 merged PRs since v0.16 — significant churn
+
+**From the broader X community (June 2026):**
+- **@Saboo_Shubham_** (May 22): "Ultimate Guide to running Free Local Coding Agents with Hermes" — SmallCode + Kanban for free local coding agent pipelines
+- **@ScottyBeamIO** (Jun 16): Full architecture guide detailing kanban_decomposer setup and multi-agent patterns
+- **The Goldie Self-Driving Board** (@agentos.guide): Community pattern for auto-managing Kanban boards with an orchestrator that rebalances tasks, detects stuck workers, and routes around failures
+- **Hermes Agent Community on X** (7.8K members): Active discussions on profile building, SOUL.md design, and Kanban pipeline patterns
+
+> **Note:** Several of these sources were extracted via search snippets and browser — some blog post content may have additional detail not captured here. Community members are encouraged to link deeper resources in the comments.
+
+### The 2-Profile Starter (recommended for everyone)
+
+The most common advice across threads — start with one orchestrator and one generalist worker:
+
+```yaml
+# config.yaml
+kanban:
+  orchestrator_profile: default
+  auto_decompose: true
+```
+
+```bash
+hermes profile create worker --clone
+# Edit worker's config: restrict tools, set model
+```
+
+### The 4-tier scaling model (u/nemanja87mn)
+
+| Tier | Setup | When |
+|------|-------|------|
+| **Tier 1** | One agent, delegate_task for subagents | Protecting context without adding complexity |
+| **Tier 2** | Orchestrator + specialist profiles, one chat surface | Multiple roles, isolated memory |
+| **Tier 3** | Domain orchestrators with separate bots | Different businesses/domains |
+| **Tier 4** | Separate instances (same machine or VPS) | Client work, production, strict isolation |
+
+Most people never need Tier 3 or 4.
+
+### Goal-mode: "keep going until done"
+
+```bash
+hermes kanban create "Translate the whole docs site to French" \
+    --body "Acceptance: every page translated, no English left, links intact." \
+    --assignee translator \
+    --goal --goal-max-turns 15
+```
+
+Workers keep running in the same session, with an auxiliary judge checking completion after every turn. Budget exhausted without done → task blocks for human review (never silent exit).
+
+### Kanban Swarm (v1)
+
+```bash
+hermes kanban swarm "Design a multi-region failover plan" \
+    --workers researcher,architect,sre \
+    --verifier reviewer --synthesizer writer
+```
+
+Creates: root/blackboard card → N parallel workers → verifier gated on all workers → synthesizer gated on verifier. All normal dispatcher lifecycle.
+
+### Multi-board for separate projects
+
+```bash
+hermes kanban boards create project-alpha \
+    --name "Project Alpha" --description "Client work" --icon 🏗️
+
+hermes kanban --board project-alpha list
+```
+
+Per-board isolation: separate SQLite DB, workspaces, logs. Workers see only their board's tasks.
+
+### The Constitution pattern (community-invented)
+
+A `constitution.md` document that defines each profile's specialty. The orchestrator reads it before routing:
+
+```markdown
+## Agent: researcher
+- Specialty: web research, docs reading, API exploration
+- Tools: web, file
+- Route: any research or discovery task
+
+## Agent: coder
+- Specialty: Python, JavaScript, system scripts
+- Tools: terminal, file, github
+- Route: any coding or implementation task
+```
+
+Orchestrator's SOUL.md: "Read constitution.md before routing. Assign to the profile whose specialty matches."
+
+### Multi-tenant setups
+
+```bash
+hermes kanban create "monthly report" \
+    --assignee researcher \
+    --tenant business-a \
+    --workspace dir:~/tenants/business-a/data/
+```
+
+Workers receive `$HERMES_TENANT` and namespace memory writes by prefix. Same board, same dispatcher, scoped data.
+
+---
+
+## Part 9: Pitfalls and Fixes
+
+### "Kanban tasks never get picked up"
+
+- **Dispatcher not running:** The gateway must be running — `hermes gateway start`. The dispatcher runs inside the gateway by default. Without it, ready tasks stay in ready forever.
+- **Profile doesn't exist:** `hermes kanban create "task" --assignee nonexistent-profile` — the dispatcher silently fails. Check with `hermes profiles list`.
+- **Config error in profile:** Spawn fails, circuit breaker trips. Check `hermes kanban runs <id> --json` for the error.
+
+### "Kanban DB got corrupted"
+
+Multiple users reported SQLite corruption in v0.14.0. The root cause was identified as **index corruption** — `idx_tasks_status` and `idx_tasks_assignee_status` out of sync from concurrent subagent writes, not data loss.
+
+**Fix (preserves all tasks and events):**
+```sql
+-- In ~/.hermes/kanban.db (or boards/<slug>/kanban.db)
+REINDEX idx_tasks_status;
+REINDEX idx_tasks_assignee_status;
+```
+
+**Workarounds from the community:**
+- Create a dedicated subagent to serialize Kanban DB writes (single point of access) — u/drmembrane
+- Switch orchestrator from auto to manual mode — u/arugrat11
+- Migrate Kanban to Postgres (long-term; Honcho already uses Postgres) — u/drmembrane
+- If all else fails: `kanban gc --event-retention-days 7` then reinitialize
+
+> Multiple users reported: "Kanban currently non-usable because constant db corruptions" — u/qettyz, u/GuCaWa, u/Supernovali
+
+**Prevent:** Back up `~/.hermes/kanban.db` and boards periodically. Use `kanban gc` to trim old events.
+
+### "Kanban deleted my projects"
+
+From a community report: setting a project folder as the working directory caused Kanban to create/delete scratch workspaces there. **Never use scratch workspaces in a production directory.** Use `dir:<path>` to pin an existing directory — scratch dirs are deleted on task completion.
+
+> "Kanban finished working and deleted its own work too! Moron kanban." — u/Popular-Penalty6719
+
+**Rule of thumb:** Always set working and outcome directories OUTSIDE your own folder structure. Either pin explicit `dir:<path>` for persistence or use an immutable flag on critical directories (`chflags uchg /your/protected/directory` on macOS).
+
+### "Infinite dispatch loop burning API tokens"
+
+If approval_mode is set to `manual` and a worker hits an SSH/SCP command that goes to `pending_approval`, the worker fails and crashes. The dispatcher spawns a NEW worker instantly, creating an infinite loop. One user reported 14 dispatches for the same task in ~90 minutes, each consuming API tokens.
+
+**Fix:** Configure workers to enter `kanban_block(pending)` status instead of failing on blocked commands. Or set `approval_mode: auto` if you trust the commands being issued.
+
+### "Worker results don't return to orchestrator"
+
+When a worker completes a task, the result doesn't always come back to the orchestrator's gateway channel. This is a known gap — the worker's `kanban_complete` writes to the DB, but there's no built-in mechanism to surface the result back to the orchestrator's chat.
+
+**Workaround:** Subscribe to the task's terminal events:
+```bash
+hermes kanban notify-subscribe <task-id> --platform telegram --chat-id <id>
+```
+Or set up a watcher: `hermes kanban watch --kinds completed`
+
+### "Workers keep timing out / crashing"
+
+- **Local model too slow:** Cap `max_in_progress` to prevent overload.
+- **Model doesn't follow tool protocol:** Worker exits without calling `kanban_complete`. The dispatcher emits `protocol_violation` and blocks the task. **Fix:** Use a model that reliably calls tools, or include explicit instructions in the worker's SOUL.md.
+- **OOM on large tasks:** Workers spawn with the profile's context window. If the task description + parent handoffs are huge, consider smaller context or chunking.
+
+### "Triage → todo promotion issues"
+
+- If `auto_decompose: true` but no decomposer is configured, triage tasks get stuck. Configure `auxiliary.kanban_decomposer` or switch to manual mode.
+- If a task in `todo` without an assignee auto-promotes to `ready`, that's by design — the dispatcher picks up unassigned tasks using `kanban.default_assignee` or the active default profile.
+
+### "Kanban feels complex"
+
+From community threads comparing Hermes Kanban to simpler systems (Paperclip, NanoClaw): the complexity trade-off is **durability + audit trail**. Hermes Kanban is an industrial-grade task board, not a lightweight todo list. If you don't need retry history, human-in-loop, or multi-agent coordination, use `delegate_task` instead.
+
+### "Agent keeps loop-de-looping with Kanban"
+
+**Hard stop guard:** Set `tool_loop_guardrails.hard_stop_enabled: true` with `hard_stop_after.exact_failure: 5`. Also set per-task `--max-retries` to prevent infinite retry loops.
+
+### "I want Kanban on multiple machines"
+
+Kanban is single-host by design. `~/.hermes/kanban.db` is a local SQLite file. For multi-host setups, run an independent board per host and bridge them with `delegate_task` or a message queue.
+
+---
+
+## Part 10: FAQ
+
+**Q: How do I start using Kanban today?**
+A: `hermes kanban init` → `hermes gateway start` → `hermes kanban create "my first task" --assignee <profile>`. The dashboard at `hermes dashboard` → Kanban tab shows the board.
+
+**Q: Do I need profiles to use Kanban?**
+A: Yes. Kanban tasks must be assigned to a profile. You can use your default profile for everything, but that defeats the purpose — the strength is routing work to specialised profiles.
+
+**Q: Can a single agent work Kanban tasks?**
+A: Yes. A single profile can claim tasks, work them, and complete them. The dispatcher serialises — one task at a time for that profile.
+
+**Q: What's the difference between a kanban worker and a normal chat session?**
+A: Workers spawn with `HERMES_KANBAN_TASK` env var, which enables the `kanban_*` toolset and injects the worker lifecycle guidance. A normal `hermes chat` session doesn't have these.
+
+**Q: Can I use Kanban with only local models?**
+A: Yes. Many users run fully local Kanban fleets. Key tuning: set `max_in_progress` to match your GPU memory, raise `dispatch_stale_timeout_seconds` for slow models, and use a smaller model for the decomposer.
+
+**Q: How do retries work?**
+A: When a worker fails (doesn't call `kanban_complete`), the dispatcher reclaims the task and tries again. After `failure_limit` consecutive failures, the circuit breaker trips and the task auto-blocks. You unblock it from the dashboard or CLI, and the retry counter resets.
+
+**Q: How do I see what went wrong on a failed task?**
+A: `hermes kanban runs <id>` shows every attempt with outcome, error, and summary. `hermes kanban log <id>` shows the worker's stdout/stderr for debugging.
+
+**Q: Can I attach files to Kanban tasks?**
+A: Yes — upload from the dashboard drawer (25 MB cap per file). Workers see attached files as absolute paths in their context.
+
+**Q: What's the best model for the decomposer?**
+A: The decomposer doesn't need to be your strongest model — it just produces a task graph. A 12-27B local model works fine. On slow decomposers, crank up `dispatch_interval_seconds` so it doesn't block the dispatcher.
+
+---
+
+## Part 11: Knowledge Table
+
+| Feature | What It Is | Best For | Watch For |
+|---------|-----------|----------|-----------|
+| **Built-in Kanban** | SQLite board, zero-config | Multi-agent durable coordination | Dispatcher must be running |
+| **Profiles** | Separate Hermes identities | Agent team with distinct memory/skills | Not filesystem sandboxes |
+| **Orchestrator pattern** | Router profile, no implementation | Task decomposition and routing | Don't give it terminal tools |
+| **Goal-mode** | Judge evaluates per-turn completion | Open-ended multi-step tasks | Auxiliary LLM cost per turn |
+| **Decomposer** | Auto-splits triage tasks into graphs | "Drop a one-liner, walk away" | Needs configured auxiliary model |
+| **Scratch workspace** | Temp dir, deleted on completion | One-off tasks | NEVER use for production data |
+| **dir: workspace** | Pinned directory | Ongoing work | Must be absolute path |
+| **worktree workspace** | Git worktree | Coding tasks | Creates real git branches |
+| **Multi-board** | Isolated per-project boards | Separate workstreams | Confusion if you forget `--board` |
+| **Skill pinning** | Per-task skills | One-off specialist context | Skill must exist on target profile |
+| **Circuit breaker** | Auto-blocks after N failures | Prevents worker thrashing | Default 2 may be too aggressive |
+| **Heartbeat** | Liveness signal | Long operations (>1 hour) | Reclaim after 1h without heartbeat |
+| **Scheduled tasks** | `scheduled_at` timestamp | Nightly ops, timed runs | UTC timestamps |
+| **Kanban Swarm** | Built-in swarm topology | Parallel workers + verifier | New feature, less battle-tested |
+| **Telegram notifications** | Auto-subscribe on `/kanban create` | Mobile notifications | Gateway must be running |
+
+---
+
+## Part 12: Quickstart — From Zero to Running Kanban in 5 Minutes
+
+```bash
+# 1. Create a worker profile (if you don't have one)
+hermes profile create worker --clone
+# Edit ~/.hermes/profiles/worker/config.yaml — restrict toolsets, set model
+
+# 2. Init kanban + start gateway
+hermes kanban init
+hermes gateway start
+
+# 3. Create your first task
+hermes kanban create "Research local LLM options for a 16GB Mac" \
+    --body "Focus on: GGUF models that fit 16GB, tool-calling reliability, Qwen3-9B vs Gemma-4-12B. Sources: reddit, huggingface, official benchmarks." \
+    --assignee worker
+
+# 4. Watch it happen
+hermes kanban watch
+
+# 5. Check the board
+hermes kanban list
+hermes kanban stats
+```
+
+---
+
+*Synthesized from official Hermes Kanban documentation, the Kanban tutorial (4 stories), the kanban-orchestrator skill, 15+ r/hermesagent threads, v0.15/v0.16/v0.17 release notes, X/Twitter posts from @NousResearch, @shannholmberg, @Saboo_Shubham_, @ScottyBeamIO, and the Hermes Agent Community on X (7.8K members). Community quotes and setups from u/rk1213, u/itsdodobitch, u/H4llifax, u/Bulky_Magician, u/Krogg, u/veganmaister, u/Zenatic, u/JobOdd7262, u/nemanja87mn, u/Starrwulfe, u/Kromi75, u/Sufficient-Rip-6219, u/drmembrane, u/Popular-Penalty6719, u/Acrobatic-Let8742, u/Nazmul-TechTips, u/Technical_Win_3568, and others. Corrections and additions welcome in the comments.*
+
+---
+
+## Comment-Sourced Updates
+
+- **Keep the team small:** every additional profile/worker carries startup context and coordination overhead. Add profiles for durable responsibility, credentials, memory, or routing boundaries—not as decoration.
+
+- **Worker handoffs:** commenters recommend a worker-specific `AGENTS.md` or equivalent handoff document, explicit completion instructions, and clear blocking criteria.
+
+- **Completion and timeouts:** tell workers when to call `kanban complete`; tune task/tool timeouts for long work; do not let a finished task remain blocked merely because a model defaults to human review.
+
+## Maintaining this guide
+
+Open an issue or pull request with the official source, date checked, Hermes/backend version, and enough reproduction detail to evaluate the change. No referral links, affiliate links, or unsupported promotional claims.

--- a/megathreads/mac-mlx-apple-silicon-2026-06.md
+++ b/megathreads/mac-mlx-apple-silicon-2026-06.md
@@ -1,0 +1,390 @@
+# Mac + MLX Megathread — Hermes Agent on Apple Silicon (June 2026)
+
+> Community-maintained GitHub version of the Reddit megathread.
+>
+> Original Reddit thread: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/
+>
+> **Snapshot:** Original post preserved and normalized; comment corrections reviewed through July 16, 2026.
+>
+> Time-sensitive prices, quotas, versions, model availability, benchmarks, and third-party project claims remain dated snapshots unless an official source is cited.
+
+---
+
+LAST UPDATED: June 21, 2026
+
+This is the every-question-answered reference for running Hermes Agent locally on Apple Silicon. Aggregated from 20+ r/hermesagent threads, GitHub issue trackers, independent benchmarks, and model documentation — all sourced within the last 45 days.
+
+---
+
+## TL;DR — What Should I Download Right Now?
+
+| Your Mac | Download This | Backend | Why |
+|----------|--------------|---------|-----|
+| 8GB | Qwen3.5-4B Q4_K_M or Gemma 4 E2B Q4 | Ollama or llama.cpp | Accept the limits. Use for simple chat, not heavy agent work. |
+| 16GB | Qwen3.5-9B Q4_K_M or MLX 4-bit | llama.cpp (best compatibility) or Ollama | The practical floor for Hermes. Preserve RAM for context — use quantized KV cache. |
+| 24GB | Qwen3.6-27B Q4_K_M OR Qwen3.6-35B-A3B 4-bit MLX | llama.cpp for dense; MLX-LM for MoE | Dense = stronger coding/predictability. MoE = much faster decode (~60 tok/s on Max). |
+| 32-48GB | Qwen3.6-35B-A3B 4-bit MLX (OptiQ if available) | MLX-LM or oMLX | The current Mac sweet spot. ~3B active per token, ~20GB file, runs like a 3B model. |
+| 48-64GB | Qwen3.6-27B Q6_K / Q8, or Qwen3.6-35B-A3B 8-bit | llama.cpp for dense quality; MLX for MoE speed | Dense Q6/Q8 is the serious-agent quant. |
+| 64-96GB | Gemma 4 26B-A4B Q4 as MoE alternative, Qwen3.6-27B Q8 | MLX or llama.cpp | Alternative MoE if you want non-Qwen. |
+| 128GB+ | Same as 64GB+ at better quants. DeepSeek V4 Flash experimental. | Same as above | More RAM = better quants + longer context. Not automatically a better model. |
+
+**Stock models first.** Uncensored variants (Heretic, HauhauCS) are advanced options — test tool calling before relying on them. The boring model that follows schema for 6+ tool calls beats the spicy one that talks itself into a ditch.
+
+---
+
+## The Backend Landscape — Which Server to Use
+
+### llama.cpp (GGUF)
+**Best for:** maximum compatibility, KV cache control, vision/mmproj, Jinja templates.
+
+```bash
+llama-server -m ~/models/model.gguf \
+  -ngl 99 -c 65536 -np 1 -fa on \
+  --cache-type-k q8_0 --cache-type-v q4_0 \
+  --host 127.0.0.1 --port 8080 --jinja
+```
+
+- Fastest time-to-first-token (TTFT) in Hermes' own testing
+- Full KV cache quantization control (critical for 16GB Macs)
+- MTP is a NET LOSS on Metal — do not enable it. Baseline Qwen3.5-9B at 25.3 tok/s → MTP drops to 19.3 tok/s at best, 1.93 tok/s on Qwen3.6-35B self-MTP (13.6x slower). See llama.cpp issues #23752 and #23011.
+- For 16GB: start at 64K context, not 128K. Move up only if needed.
+
+### MLX-LM / oMLX
+**Best for:** maximum generation speed on MoE models.
+
+```bash
+pip install mlx-lm
+mlx_lm.server --model mlx-community/Qwen3.6-35B-A3B-4bit --port 8000
+```
+
+- 20-30% faster than llama.cpp on generation, gap widens on larger models
+- Qwen3.6-35B-A3B 4-bit: 61.2 tok/s vs 16.7 tok/s for dense 27B 4-bit (M1 Max 64GB test)
+- KNOWN BUGS (June 2026):
+  - Qwen3.5/3.6 non-Coder models may fail to emit tool_calls — parser auto-detection doesn't match their chat templates (mlx-lm issue #1293)
+  - MTP variants return 1-2 token completions on second requests (mlx-lm issue #1292) — use non-MTP MLX variants for multi-turn
+  - Prompt cache failure on Qwen3-Next hybrid architectures (mlx-lm issue #1162)
+
+### Ollama
+**Best for:** easiest setup, zero config.
+
+```bash
+brew install ollama
+ollama pull qwen3.6:35b-a3b-mlx
+ollama serve
+```
+
+- MLX backend since v0.19: 2x decode speed, ~1.6x prefill speed on M5 Max
+- v0.30.x added Gemma 4 MLX support and flash attention auto-enable
+- Community split: some users prefer Ollama MLX for snappiness and RAM distribution; others prefer raw MLX-LM server for speed (Ollama is still a llama.cpp wrapper underneath for non-MLX models)
+- KNOWN BUGS (June 2026):
+  - KV cache memory leak: v0.30.8 on M4 Max 64GB, memory grows from ~24GB to 75GB, token generation collapses under swap (issue #16698)
+  - Inter-prompt delay regression on Apple Silicon MLX (issue #16170, v0.24.0)
+  - If Hermes loops tools or gets slow, test the same model through llama.cpp or MLX-LM before blaming the model
+
+### LM Studio
+**Best for:** GUI model management, non-terminal users.
+
+- Exposes OpenAI-compatible API on port 1234
+- Supports both GGUF and MLX paths
+- Community experience: even on 36GB M4 Max with Gemma 26B, one user reports "it randomly forgets about installed tools, fails to report expired tokens, sometimes doesn't answer at all"
+- KNOWN BUGS:
+  - Tool-calling parser breaks Qwen3.5 in some versions — generates correct JSON but LM Studio truncates or misparses it
+  - Gemma 4 tool calls: MLX backend leaks raw function markers into message content; GGUF backend has a working parser but runs ~50% slower
+  - Upgrade to latest version before troubleshooting
+
+### Rapid-MLX (NEW — June 2026)
+**Best for:** maximum speed on Apple Silicon, especially agentic/tool-calling workloads.
+
+- 2-4x faster than Ollama, 0.08s cached TTFT
+- 17 tool parsers, 100% tool calling support
+- Drop-in OpenAI replacement — works with Hermes, Claude Code, Cursor, Aider
+- 3,000+ GitHub stars, actively maintained (commits as of June 21, 2026)
+- Currently the strongest Mac backend for tool-calling reliability
+
+### Lightning MLX
+Fork of Rapid-MLX optimized for agentic use — short streamed turns, tool calls, low-latency interactions. Claims 220 tok/s on compatible hardware.
+
+---
+
+## Model Deep Dive
+
+### Qwen3.6-35B-A3B — The Current Mac Default (32GB+)
+
+Released April 16, 2026. MoE: 35B total, ~3B active per token. Apache 2.0.
+
+- GPU QA Diamond: 86.0. SWE-bench: 73.4%.
+- Native context: 262K (extendable to ~1M via YaRN)
+- Best quants: MLX 4-bit (~20.4GB), OptiQ 4-bit (mixed 4/8-bit, better BFCL/HashHop)
+- Uncensored: HauhauCS Aggressive, DavidAU Heretic (advanced only)
+- Chat template: use Jinja. Tool calls require correct template — stock is fine on modern runtimes, fall back to `spiritbuun/buun-Qwen3.6-chat_template` if breaking
+
+**Sampling for Hermes agent work:**
+- Thinking ON, temp 0.6, top_p 0.95, top_k 20 (coding/tools)
+- Thinking ON, temp 0.8-1.0, top_p 0.95, top_k 20 (research/chat)
+- Non-thinking: temp 0.7, top_p 0.8, top_k 20, presence_penalty 1.5
+
+### Qwen3.6-27B Dense — Best Dense Coding Pick (24GB+)
+
+Released April 22, 2026. 27B dense. Apache 2.0. SWE-bench Verified: 77.2.
+
+- Simon Willison clocked Unsloth Q4_K_M at 25.57 tok/s with flagship-class results
+- Best quants: Q4_K_M (24GB, 16.8GB file), Q5_K_M (32GB+), Q6_K/Q8 (48GB+)
+- Q6 is the preferred serious-agent quant — Q4 works but can drift on long tool traces
+- Heretic NEO-CODE variant: 523K+ downloads (DavidAU, last modified June 11, 2026)
+
+### Qwen3.5-9B — Best 16GB Floor
+
+Mature, well-documented, official Hermes Mac starter model.
+
+- Best quants: Q4_K_M GGUF (practical default) or MLX 4-bit
+- Q6_K if you have room — better tool reliability
+- Official Hermes docs recommend it as the starter model for constrained Macs
+- HauhauCS Aggressive available for uncensored use
+
+### Gemma 4 Family — Best Cross-Family Alternative
+
+- **Gemma 4 12B:** Google positions for local agentic/multimodal laptop workflows (June 3, 2026 post). Viable 16-24GB candidate.
+- **Gemma 4 26B-A4B:** 26B total, ~4B active. Good 32GB+ MoE alternative. 256K context.
+- **Gemma 4 31B:** Dense. 64GB+ preferred.
+- **Gemma 4 E2B/E4B:** Lighter models. Good as fast aux/routing models.
+- Known issue: mac-llm-bench scores unusually low on Gemma 4 due to llama.cpp tool-calling bug causing premature inference stopping — not actual model capability.
+- Thinking mode: add `<|think|>` at start of system prompt. Don't feed prior thought blocks back into history.
+
+---
+
+## Critical Pitfalls — Read This Before You Waste 4 Hours
+
+### 1. MTP = Slower on Mac (Not Faster)
+Unsloth and model cards market 1.4-2.2x speedups from MTP. On Apple Silicon Metal, it's a NET LOSS at every configuration. llama.cpp #23752 confirms: baseline 25.3 tok/s → MTP 19.3 tok/s (-24%). Qwen3.6-35B self-MTP: baseline 26.2 tok/s → MTP 1.93 tok/s (-92%). Do not enable `--spec-type draft-mtp` on Mac.
+
+### 2. Tool Calling Breaks Across Backends
+The tool-calling stack on Mac is the #1 failure mode for Hermes users:
+- **MLX-LM:** Qwen3.5/3.6 non-Coder tool parser mismatch
+- **Ollama MLX:** KV cache leak causes swap death, tool loops hang
+- **LM Studio:** Parser truncates Qwen tool calls, Gemma MLX leaks raw markers
+- **Fix:** test `/v1/chat/completions` with a tool-calling prompt before trusting any backend. If one backend fails, try another before blaming the model.
+
+### 3. 16GB Is the Floor, Not the Sweet Spot
+Usable memory after macOS and apps is ~10-12GB. That's Qwen3.5-9B Q4_K_M + 64K context with quantized KV. Forcing a 14B/27B into swap will feel terrible. Use a strong 9B at a decent quant over a crippled larger model.
+
+**And 2B models are not viable for Hermes tool use.** One user tested gemma4:e2b on a Mac Mini M4 16GB with oMLX: "can't even handle one request — 'list my Google Drive files'." Gemma4:e4b generated invalid tool calls. Qwen3.5-9B "spent 15 minutes... sort of worked." Community consensus: 7B-9B is the minimum for tool calling. 2B-4B models are chatbots, not agents.
+
+### 4. Bandwidth > Chip Generation
+An M3 Max (400 GB/s) generates tokens faster than an M4 Pro (273 GB/s). For LLM inference, memory bandwidth is the bottleneck. When shopping Macs for Hermes: Max > Pro > base, even if it's a generation older.
+
+### 5. Agent Context Tax — Hermes Burns Tokens Just to Say "Hi"
+Multiple users report that Hermes' orchestrator overhead consumes massive context before the model even starts working. One user measured: "when I say 'hi' the agent takes around 15K tokens to reply." Another: "you could be waiting for a reply and it's off carefully writing a new skill. I've walked away, thinking it had died and 30 minutes later it returns."
+
+This is especially punishing on local Macs where context = RAM. Fixes:
+- Use quantized KV cache to reduce the memory cost of bloated context
+- Keep context windows conservative (64K, not 128K+) unless your workflow demands it
+- Consider using a smaller/faster model as orchestrator and delegating heavy work to cloud sub-agents
+- One user fine-tunes Gemma 4 E4B as a lightweight orchestrator that delegates to frontier models
+
+### 6. KV Cache Is the Hidden Memory Killer
+Context eats RAM faster than model weights. On a 16GB Mac with Qwen3.5-9B Q4_K_M, 128K context with fp16 KV cache can use 8GB for cache alone. Always use quantized KV:
+```bash
+--cache-type-k q8_0 --cache-type-v q4_0
+```
+Ollama users: set `OLLAMA_KV_CACHE_TYPE=q8_0` and `OLLAMA_FLASH_ATTENTION=1`.
+
+**Proven fix from the community:** One M3 Pro 18GB user went from timeouts to "now I can have a conversation" by combining KV cache 4-bit quantization + Hermes 0.8.0 lazy skill loading + 40K context window. First message still ~14K tokens but subsequent drops to ~600 tokens.
+
+### 7. Qwen Overthinks — Turn Thinking Off on Constrained Macs
+Qwen models are known to overthink on even the simplest prompts. On RAM-limited Macs, long thinking chains plus Hermes' already-heavy system prompt can push you into timeout territory instantly. A simple fix that worked for multiple users: turn thinking off. It's not ideal for complex multi-step tasks, but it's the difference between "works" and "stares at a wall for 15 minutes then times out" on 16-18GB machines.
+
+---
+
+## Hermes Agent Setup Commands
+
+For any local OpenAI-compatible server:
+
+```bash
+# Verify your model endpoint works
+curl -s http://127.0.0.1:8080/v1/models
+
+# Configure Hermes
+hermes config set model.provider custom:local-mac
+hermes config set model.base_url http://127.0.0.1:8080/v1
+hermes config set model.api_key local-no-key
+hermes config set model.default MODEL_ID_FROM_ABOVE
+```
+
+For the Desktop app (released June 2, 2026, v0.15.2): same config pattern, set the provider to your local endpoint.
+
+---
+
+## What the Community Is Actually Running
+
+These are real setups from r/hermesagent users in May-June 2026:
+
+| User | Hardware | Model | Speed | Notes |
+|------|----------|-------|-------|-------|
+| Britbong1492 | M4 Max | Qwen3.6:35B-A3B local | ~80 t/s, TTFT 0.3s | 95% local, 5% Kimi k2.6 fallback. ~$1/week/agent |
+| 310dweller | M4 Mac mini 32GB | Gemma 4 26B 4-bit MLX via oMLX | faster than Ollama cloud | "Thinking loops locally" were tricky to tune |
+| Tacamaniac | M1 Max 64GB | Qwen 7B + 35B on MLX | — | Migrated from Docker to native macOS. Testing vs GPT-5.5: "It performs better. However in 10 minutes of trying, it cost me $1.50." |
+| italianamerican985 | M1 Ultra 128GB | Qwen3.6-35B Q4 | 80 t/s | "Felt like it made a lot of mistakes compared to Minimax or 27B." MTP did not produce speed gains |
+| EfficientShop5015 | M2 Max 32GB | — | — | "Usable locally but nothing like API." |
+| TanguayX | M2 Ultra 64GB | Qwen3.5, Gemma 4 | — | "Context window second half is useless as it's so slow." Notes Hermes orchestrator overhead as bottleneck, not model speed |
+| asankhs | Apple Silicon | Qwen3.5-9B OptiQ 4-bit | — | Recommends OptiQ quants for Mac: huggingface.co/mlx-community/Qwen3.5-9B-OptiQ-4bit |
+| BassAzayda | 16GB VRAM GPU | Qwen3.6 35B A3B | — | "Done over 42 tool calls no problems — first time I had a stable conversation" |
+| GyGeek | Framework Desktop 128GB | Qwen3.6-27B-Q8_0 | — | "Kind of slow but effective." AMD Ryzen AI Max+ 395, Radeon 8060S |
+
+**Takeaway:** The M4 Max + Qwen3.6:35B-A3B is emerging as the community's best local Hermes setup. M1/M2 Ultra users with more RAM are hitting different bottlenecks — agent overhead, context window slowdown, not model capability.
+
+---
+
+## FAQ — Real Questions from r/hermesagent
+
+**Q: I have a Mac Mini M4 32GB. Why is Qwen3.5-9B failing at tool calling?**
+A: It's likely not the model — it's the backend. If you're on Ollama, try the MLX backend explicitly (`qwen3.5:9b-mlx`). If that fails, switch to llama.cpp or test Rapid-MLX. Qwen3.5-9B is capable of tool calling; backends often break the parser.
+
+**Q: Can I run Hermes on a 16GB MacBook?**
+A: Yes — use Qwen3.5-9B Q4_K_M with quantized KV cache and 64K context. Don't expect heavy multi-tool sessions. It works for research, chat, and simple automation.
+
+**Q: Why is my model generating 3 tok/s when benchmarks say 25+?**
+A: Three common causes: (1) model fell back to CPU — verify with `-ngl 99` in llama.cpp or check Ollama GPU usage; (2) you enabled MTP — disable it immediately on Mac; (3) your context window is too large and you're in swap.
+
+**Q: MLX or GGUF — which is better for Hermes?**
+A: MLX for generation speed, especially on MoE models. GGUF/llama.cpp for KV cache control, vision support, and maximum compatibility. For Hermes tool loops, llama.cpp's predictable behavior often wins despite slower raw generation.
+
+**Q: Should I use Ollama, LM Studio, or raw llama.cpp/MLX-LM?**
+A: Ollama for easiest setup. LM Studio for GUI comfort. llama.cpp/MLX-LM for maximum control and debugging. Rapid-MLX if speed and tool-calling reliability are your top priorities.
+
+**Q: Is Qwen3.6-35B-A3B good enough to replace cloud models?**
+A: For most Hermes workflows — yes. 35B parameters with MoE delivers flagship-class behavior on Mac. The community consensus is that it's the 2026 default for 32GB+ Macs. It won't match GPT-5.5/Claude on extremely complex multi-step reasoning, but it handles files, code, web, and structured output reliably.
+
+**Q: What about uncensored models for Hermes?**
+A: Start with stock. If you want uncensored, Heretic and HauhauCS Balanced are the best-documented. Aggressive/Huihui builds exist but test tool calling before relying on them. Uncensored ≠ better agent.
+
+**Q: I have an M1 Ultra 128GB and I'm struggling. Why?**
+A: This is a real question from the subreddit. More RAM doesn't solve backend bugs. Verify your backend (Ollama vs llama.cpp), check for MTP being enabled, test a simple model first, and make sure KV cache is quantized. But also: one user found that "the agent itself eats up a lot of memory/resources — when I say 'hi' the agent takes around 15K tokens to reply." The hardware is capable — the software stack and agent overhead are usually the bottlenecks.
+
+**Q: Does the M5 chip make a big difference for Hermes?**
+A: M5 Max has ~614 GB/s bandwidth vs M4 Max's ~546 GB/s — about 12% faster token generation. The bigger story is the M5 Neural Accelerators, which Apple claims give 4x TTFT gains for MLX models. Real-world: modest improvement, but not game-changing for LLM inference vs. M4 Max. Supply is constrained as of June 2026.
+
+**Q: Gemma 4 or Qwen3.6 — which should I use?**
+A: Qwen3.6-35B-A3B for speed and agentic coding. Gemma 4 26B-A4B if you want a non-Qwen MoE alternative or need multimodal/image capabilities. Both are strong; Qwen has more community validation for Hermes specifically.
+
+**Q: What's the fastest inference engine for Mac right now?**
+A: Rapid-MLX (June 2026) claims 2-4x faster than Ollama with 100% tool calling. Lightning MLX claims 220 tok/s. Both are newer/less battle-tested than llama.cpp and Ollama. For reliability, stick with llama.cpp or Ollama. For speed, test Rapid-MLX.
+
+**Q: Is the hybrid cloud/local approach worth it?**
+A: Yes — it's the current community consensus. The top-voted comment on the biggest local-models thread (+35) recommends a $20 Codex plan as fallback. One M4 Max user runs 95% Qwen3.6:35B-A3B local (~80 t/s, TTFT 0.3s) and falls back to Kimi k2.6 at under $1 per million tokens, totaling about $1/week. This pattern — fast local for routine work, cheap cloud for hard tasks — is the practical sweet spot.
+
+**Q: Should I use Hermes for coding on a local Mac?**
+A: The community is split. Some (including the "Running Locally, Really?" OP) say "Hermes is not for coding — it's an orchestration agent. Use Claude Code or OpenCode as a sub-agent." Others successfully code with Qwen3.6-35B-A3B or Qwen3.6-27B locally. The consensus: Hermes excels at orchestrating — delegating coding tasks to specialized sub-agents. If you want a single model that directly writes code, the cloud frontier models still have an edge.
+
+**Q: I have a brand-new M4 Max with 36-48GB. Will everything just work?**
+A: Not automatically. One M4 Max 36GB user reports that even with Gemma 26B, Hermes "randomly forgets about installed tools, fails to report expired tokens, sometimes doesn't answer at all." The hardware is capable but the software stack — backend bugs, agent context overhead, tool calling edge cases — is the real bottleneck. Start with Qwen3.6-35B-A3B on MLX-LM or Ollama MLX, verify tool calling, and lower your context window before raising it.
+
+---
+
+## Quick Backend Decision Matrix
+
+| You Want... | Use This | Avoid |
+|-------------|----------|-------|
+| Fastest setup | Ollama | — |
+| Best tool-calling reliability | llama.cpp or Rapid-MLX | Ollama MLX (KV cache leak), LM Studio (parser bugs) |
+| Fastest generation | Rapid-MLX or MLX-LM | — |
+| Vision/multimodal | llama.cpp + mmproj | MLX-LM (text-only) |
+| Long context (128K+) | llama.cpp + quantized KV + TurboQuant | Ollama on 16GB (memory leak risk) |
+| GUI without terminal | LM Studio | — |
+| Uncensored models | llama.cpp + Heretic/HauhauCS GGUF | MLX (fewer uncensored builds) |
+| MTP speed boost | NVIDIA GPU, not Mac | MTP on Apple Metal (net loss) |
+
+---
+
+## Temperature & Sampling Quick Reference
+
+For Hermes agent work with Qwen3.6:
+
+| Workload | Thinking | Temp | Top-P | Top-K | Presence Penalty |
+|----------|----------|------|-------|-------|-----------------|
+| Coding / tool loops | ON | 0.6 | 0.95 | 20 | 0.0 |
+| Research / chat | ON | 0.8-1.0 | 0.95 | 20 | 0.0 |
+| Summarization (latency matters) | OFF | 0.7 | 0.8 | 20 | 1.5 |
+| Precise structured output | ON | 0.6 | 0.95 | 20 | 0.0 |
+
+For non-thinking mode: `--chat-template-kwargs '{"enable_thinking":false}'` in llama.cpp.
+
+---
+
+## Sources
+
+All sources from the last 45 days (May 7 – June 21, 2026):
+
+### Reddit Threads (r/hermesagent)
+- Best Small Models for Hermes on Mac Mini M4: https://redd.it/1sq5802
+- Running Hermes with Local Models: https://redd.it/1tegogu
+- How to Run Hermes for Free: https://redd.it/1tqzwl9
+- M1 Ultra 128GB Struggling: https://redd.it/1toi897
+- Running Locally, Really?: https://redd.it/1snju8w
+- I Curated the Best Local Models: https://redd.it/1stiwug
+- Hermes Agent Using Local LLM: https://redd.it/1tvrb2r
+- 4 Hours Setting Up Hermes Locally — Reality Check: https://redd.it/1u1u4ke
+- Hermes and Local Qwen3.5-9B: https://redd.it/1sgogsr
+- Yes, Hermes and Qwen3.5:4B Is All I Need: https://redd.it/1snfnq9
+- Any Luck with Local Gemma4:E2B?: https://redd.it/1swl63u
+- Best Free Model for Hermes: https://redd.it/1tijj0c
+- Best Ollama Model for Local Only: https://redd.it/1u56mbi
+- What Model Are You Running?: https://redd.it/1t3lscj
+- AMA Summary from r/LocalLLaMA: https://redd.it/1szctp1
+- Models Megathread May 2026: https://redd.it/1tgbsuz
+- Looking for Hermes Best Practices: https://redd.it/1tlnmw3
+- Qwen3.6-35B-A3B Definitive Guide: https://redd.it/1tmp2qy
+- Qwen3.6-27B Definitive Guide: https://redd.it/1tn4lye
+- Please Critique My Hermes Setup: https://redd.it/1ti2s9u
+
+### GitHub Issues
+- llama.cpp #23752: MTP degrades throughput on Metal (May 27, 2026)
+- llama.cpp #23011: Qwen3.6-35B self-MTP much slower on Metal (May 13, 2026)
+- mlx-lm #1293: Qwen3.5/3.6 tool parser mismatch
+- mlx-lm #1292: Qwen3.6 MTP variant multi-turn failures
+- mlx-lm #1162: Prompt-cache failure on Qwen3-Next hybrid
+- Ollama #16698: MLX KV cache memory leak on M4 Max (v0.30.8)
+- Ollama #16170: Inter-prompt delay regression on MLX (v0.24.0)
+
+### Articles & Benchmarks
+- Hermes Agent Docs — Run Local LLMs on Mac: https://hermes-agent.nousresearch.com/docs/guides/local-llm-on-mac
+- InsiderLLM — Best Local LLMs for Mac 2026: https://insiderllm.com/guides/best-local-llms-mac-2026/
+- Rapid-MLX: https://github.com/raullenchai/Rapid-MLX
+- Lightning MLX: https://github.com/samuelfaj/lightning-mlx
+- Apple ML Research — MLX on M5: https://machinelearning.apple.com/research/exploring-llms-mlx-m5
+- ModelFit — Speculative Decoding on Mac: https://modelfit.io/blog/speculative-decoding-mac-llm/
+- Unsloth — Qwen3.6 Local Guide: https://unsloth.ai/docs/models/qwen3.6
+- Unsloth — Gemma 4 Local Guide: https://unsloth.ai/docs/models/gemma-4
+- HuggingFace — mlx-community/Qwen3.6-35B-A3B-4bit: 93K downloads/month
+- HuggingFace — mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit: modified June 19, 2026
+- HuggingFace — Ornstein-Hermes-3.6-27B-MLX-6bit: ~22.6GB, good for 32GB Macs
+- mac-llm-bench: https://github.com/enescingoz/mac-llm-bench
+- LM Studio Changelog: https://lmstudio.ai/changelog
+- Ollama MLX Performance: https://craftrigs.com/news/ollama-0-19-mlx-apple-silicon-speed/
+- Local AI Master — Mac Buying Guide: https://localaimaster.com/blog/apple-silicon-ai-buying-guide
+- LLMCheck Benchmarks: https://llmcheck.net/benchmarks
+- SitePoint — Local LLMs on Apple Silicon 2026: https://www.sitepoint.com/local-llms-apple-silicon-mac-2026/
+- Ollama MLX vs Metal: https://andrew.ooo/answers/ollama-mlx-vs-ollama-metal-apple-silicon-2026/
+- LM Studio Apple Silicon Errors & Fixes: https://ianlpaterson.com/blog/lm-studio-fix-cannot-truncate-prompt-n-keep-n-ctx/
+- Google AI — Gemma 4 12B Local Agentic: https://developers.googleblog.com/bringing-gemma-4-12b-to-your-laptop-unlocking-local-agentic-workflows-with-google-ai-edge/
+
+---
+
+## Contribute
+
+Found a better config? Discovered a bug fix? Running a model/backend combo not listed here? Drop it in the comments. This megathread updates as the stack evolves.
+
+*Last refreshed: June 21, 2026. Models, backends, and bugs change weekly — check post dates on linked sources.*
+
+---
+
+## Comment-Sourced Updates
+
+- **Shared-machine contention:** running the desktop/UI and local inference on the same constrained Mac can compete for memory/GPU resources. A TUI or split host/VM architecture may be more stable.
+
+- **Backend benchmarks vary:** Rapid-MLX, oMLX MTP, LM Studio, llama.cpp, and other throughput reports depend on model, quant, context, cache, OS, and hardware. Treat reported tokens/sec as examples, not rankings.
+
+- **Unresolved candidates:** Apple Container support, Atomic.Chat, DwarfStar, NEX-N2 mini, and other comment suggestions require current compatibility checks before recommendation.
+
+## Maintaining this guide
+
+Open an issue or pull request with the official source, date checked, Hermes/backend version, and enough reproduction detail to evaluate the change. No referral links, affiliate links, or unsupported promotional claims.

--- a/megathreads/models-providers-plans-2026-07.md
+++ b/megathreads/models-providers-plans-2026-07.md
@@ -1,0 +1,378 @@
+# Models, Providers & Plans Megathread — June 2026
+
+> Community-maintained GitHub version of the Reddit megathread.
+>
+> Original Reddit thread: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/
+>
+> **Snapshot:** Original post preserved and normalized; comment corrections reviewed through July 16, 2026.
+>
+> Time-sensitive prices, quotas, versions, model availability, benchmarks, and third-party project claims remain dated snapshots unless an official source is cited.
+
+---
+
+**LAST UPDATED:** June 25, 2026
+**Sourced from:** 31+ r/hermesagent threads, 290+ community comments, [May 2026 Models Megathread](https://www.reddit.com/r/hermesagent/comments/1tgbsuz/) by u/digitalnomadpdx
+
+**Scope:** Cloud APIs, subscription plans, provider comparison, model selection, and routing strategies. For local/self-hosted models, see the [Mac/MLX Megathread](https://www.reddit.com/r/hermesagent/comments/1uc7rw5/) and [r/hermesagent Local Models Guide](https://www.reddit.com/r/hermesagent/comments/1stiwug/).
+
+---
+
+## TL;DR — What Should I Use?
+
+| Decision | Community Pick | Runner-Up | Notes |
+|----------|---------------|-----------|-------|
+| **Best overall (paid API)** | DeepSeek v4 Pro (direct) | DeepSeek v4 Flash | Pro for orchestrator, Flash for workers/auxiliary. $60 got one user 8B tokens. |
+| **Best value subscription** | OpenCode Go ($10/mo) | Minimax $10 token plan | OpenCode Go = "~$60 API credit for $10." Minimax = "virtually unlimited" background agent work. |
+| **Best premium subscription** | Nous Portal ($20) | OpenAI Codex ($20 ChatGPT) | Fixed monthly cost, no billing surprises |
+| **Best free model (no catch)** | owL-alpha (OpenRouter) | Nemotron 3 Super 120B (free) | "Absolute beast at tool usage." Best free tier for Hermes agentic tasks. |
+| **Best coding model** | GPT-5.5 (via Codex) | DeepSeek v4 Pro | GPT-5.5 is the "undisputed king" for complex coding. |
+| **Best orchestrator model** | GPT-5.4-mini | DeepSeek v4 Flash | Fast, cheap, handles 90% of routing/web search/light tasks. |
+| **Best provider for predictable billing** | OpenCode Go + Minimax stack | Nous Portal | Subscriptions = no surprise $100 days. Go+Minimax = $20/mo for near-unlimited. |
+
+---
+
+## PART 1: Cloud Provider Comparison
+
+### Tier 1 — Community Favorites
+
+| Provider | Pricing | Model Access | Best For | Watch For |
+|----------|---------|-------------|----------|-----------|
+| **DeepSeek (direct API)** | Flash: ~$0.22/M in, $0.20/M out (cache reads $0.004/M). Pro: ~$0.44/M in, $0.87/M out. Real-world: $0.30–$1.30/day for Flash, $2–6/day for Pro. | v4 Pro, v4 Flash, Coder | Primary orchestrator, heavy coding, cost-sensitive workflows | Direct API 4-5x cheaper than via OpenRouter. Throttling/503 errors during US peak hours (single-digit t/s). |
+| **OpenCode Go** | **$10/mo** ($5 first month). ~$60 worth of credits at list prices. | DeepSeek Flash/Pro, Minimax M3, MiMo 2.5 Pro, GLM, Kimi, and more | **Best overall value subscription.** Covers 90% of agent workload. No concurrency limits. | Lacks some multimodal models (Gemma 4). Weekly/monthly caps. |
+| **Nous Portal** | $20/mo subscription | Hermes models, DeepSeek, Qwen, routing | All-in-one convenience, predictable billing | Some models cost extra credits; check usage dashboard. Using non-free models exhausts $20 quickly. |
+| **OpenAI Codex** | $20/mo (ChatGPT Plus BYOK) | GPT-5.5 (undisputed king for coding), GPT-5.4-mini (ultra-fast orchestrator) | Complex coding, deep reasoning. Best used as "senior fixer" — not as daily driver. | Burns weekly rate limits fast if overused. OAuth only. Shares ChatGPT rate limits. |
+
+### Tier 2 — Strong Alternatives
+
+| Provider | Pricing | Model Access | Best For | Watch For |
+|----------|---------|-------------|----------|-----------|
+| **MiniMax** | **Historical June 2026 snapshot:** $10/mo token plan and the listed quotas. Commenters later reported that the $10 plan was replaced by a $20 plan; verify the current official plan before purchase. | M3, M2.7 | Background agent work and auxiliary tasks | Community quality descriptions are subjective. Verify current quotas, model names, and loop behavior. |
+| **Xiaomi MiMo** | **Historical June 2026 snapshot:** $6/mo direct token plan; annual/token figures were community-reported. | MiMo 2.5, MiMo 2.5 Pro | Agentic tasks, vision, coding | Cache behavior appears route-specific: direct API reports differed from OpenRouter. Test cache hits and billing on the route you will use. |
+| **Kimi/Moonshot** | Pay-per-token via OpenRouter or direct | K2.6 (very intelligent, strong tool calling), K2.7 | Best open-source Hermes main model. "Built my entire Debian server stack." | Strict quota limits. Occasional Chinese chars in output. Tends to overthink on coding. |
+| **OpenRouter** | Pay-per-token (variable). Free tier available with $10 credit. | 200+ models. **owL-alpha (free)** is the best free model — "absolute beast at tool usage and coding." | Model experimentation, fallback chains, free-tier models | Variable pricing; same model costs 4-5x more through resellers. Avoid auto-routing. Pin models to specific providers. |
+| **Gemini (Google)** | Pay-per-token / free tier | Flash 2.5 (free), Pro 2.5 | Free tier for light tasks, strong vision | Rate limits on free tier; OAuth subscription risky as BYOK |
+| **Ollama Cloud** | $20/mo ($22 credits), $100 tier | Free/open models only | Hassle-free hosted local-style models | **3 concurrent connection limit** — cron jobs crash if chatting simultaneously. Recently degraded (server busy, slow tokens). No frontier models. |
+
+### Tier 3 — Budget / Niche
+
+| Provider | Pricing | Best For | Watch For |
+|----------|---------|----------|-----------|
+| **GLM 5.1 / 5.2 (NeuralWatt)** | Free $5 credit, then PAYG. GLM-5.1 is very efficient and cheap. | Deep reasoning when speed doesn't matter. Stable, reliable. | 5.2 pricier. Painfully slow (18hrs for what GPT-5.5 does in 1hr). Prone to looping. |
+| **Anthropic Claude (sub)** | $20/mo subscription | Opus 4.7 — high-quality reasoning, code review | Agentic use explicitly discouraged by Anthropic. Too expensive as primary. Token hog. |
+| **NVIDIA NIM** | Free tier | Nemotron 3 Super 120B (free) — best emergency fallback when GPT limits hit | Smaller ecosystem; genuinely free |
+| **Grok / superGrok** | $10/mo or $30/mo X Premium | Multi-modality, voice, good tool calling | X Premium $30/mo gives only ~2hrs agent work. API gives much more. Weak at coding. |
+| **NanoGPT** | $12/mo | Only if you need uncensored models | "Sketchy AF." Slow, low limits. Models overly verbose. Not recommended as primary. |
+| **Qwen OAuth** | Subscription / pay-per-token | Qwen models direct | Newer provider; fewer community data points |
+| **OpenCode Zen** | $10/mo | Curated model selection | Smaller model selection than Go. Go is the better value. |
+
+---
+
+## PART 2: Model Comparison — Which Model for Which Task
+
+Community consensus on which cloud models excel at which role. All accessible via the providers in Part 1.
+
+### 🥇 Tier 1 — Best-in-Class
+
+| Model | Best For | Access Via | Real-World Notes |
+|-------|----------|-----------|-----------------|
+| **GPT-5.5** | Complex coding, deep reasoning, research | OpenAI Codex ($20/mo), OpenAI API | "Undisputed king" — from 6B-token test. Writes economic journal articles. Burns rate limits fast. |
+| **DeepSeek v4 Pro** | Daily driver, heavy coding, multi-step synthesis | DeepSeek direct API, OpenCode Go, Nous Portal | "Smarter than Claude Sonnet." $60 for 8B tokens over 2-3 weeks. Best value powerhouse. |
+| **DeepSeek v4 Flash** | Orchestrator, routing, 90% of daily tasks | DeepSeek direct API (free tier available), OpenCode Go | $0.30–$1.30/day. With `reasoning=xhigh` can exceed Pro in some domains. Cache hits at $0.004/M. |
+| **Claude Opus 4.7** | Highest-quality reasoning, code review | Anthropic subscription ($20/mo), OpenRouter | Brilliant but expensive. Token hog. Not for daily driving. Best as CLI-invoked code reviewer. |
+
+### 🥈 Tier 2 — Strong Performers
+
+| Model | Best For | Access Via | Real-World Notes |
+|-------|----------|-----------|-----------------|
+| **GPT-5.4-mini** | Ultra-fast orchestrator, routing | OpenAI Codex, OpenAI API | Handles 90% of routing/web search. Pair with GPT-5.5 for heavy lifting. |
+| **Kimi K2.6** | General daily agent, coding, tool calling | OpenRouter, Kimi direct API | "Built my entire Debian server stack and moved 5 agents." Very intelligent, inexpensive. Strict quotas. |
+| **Minimax M3** | Background agent work, stable everyday use | Minimax $10 token plan, OpenCode Go | "As good as GPT-5.5-low." The $10/mo "virtually unlimited" plan eliminates token anxiety. |
+| **MiMo 2.5 Pro** | Agentic intelligence, coding, vision | Xiaomi $6-13/mo plan, OpenCode Go | Strong multi-modality, good coding. "Steal at current price." No caching — burns faster. |
+| **Gemini 3.1 Pro** | Research, multi-modal, strong in custom pipelines | Google API, OpenRouter | Mixed community reception but holds up in custom agent pipelines. |
+
+### 🥉 Tier 3 — Budget & Specialist
+
+| Model | Best For | Access Via | Real-World Notes |
+|-------|----------|-----------|-----------------|
+| **owL-alpha** | Best free model — tool usage and coding | OpenRouter (free tier) | "Absolute beast at tool usage." Rate-limited for heavy multi-step loops. |
+| **Nemotron 3 Super 120B** | Emergency fallback, free coding | NVIDIA NIM (free), OpenRouter (free) | Best fallback when everything else is rate-limited. Free. |
+| **GLM-5.1** | Deep reasoning when speed doesn't matter | NeuralWatt (free $5 credit) | Stable, reliable. Painfully slow (18hr vs 1hr for GPT-5.5). |
+| **Grok 4.3** | Multi-modality, voice, general agent | Grok API, X Premium | API gives much more than $30/mo X Premium sub (only ~2hrs agent work). |
+| **Gemini 2.5 Flash** | Free tier, strong vision, light tasks | Google API (free tier) | Free. Good for light automation. Rate limits on heavier use. |
+| **Qwen 3.6** (API) | Reliable function calling, cheap API rates | OpenRouter, Qwen OAuth | Reliable tool use. Rate limits on free tier. |
+
+---
+
+## PART 3: Subscription vs Pay-Per-Use
+
+### Use a subscription ($10-20/mo fixed) if:
+
+- You want predictable billing (no $100 surprise days)
+- You use Hermes daily for extended sessions
+- You prefer "set and forget" without monitoring token burn
+- You're new to Hermes and don't know your usage patterns yet
+
+### Use pay-per-token (DeepSeek direct, OpenRouter) if:
+
+- Your usage is bursty (heavy days, then light days)
+- You're extremely cost-sensitive and willing to monitor usage
+- You run multiple worker profiles on cheaper models
+- You can self-manage fallback chains and routing
+
+### Hybrid strategy (most common in community):
+
+> *"I use OpenAI $20/mo + DeepSeek v4 Flash for workers. Pro for main orchestrator. Multiple providers so I never hit a single rate limit."* — from "Affordable and good Models" thread
+
+Pattern: Subscription for primary → cheap pay-per-token for workers/auxiliary. This is the most-recommended approach across 5+ threads.
+
+---
+
+## PART 4: Provider Reliability & Gotchas
+
+### DeepSeek
+- ✅ Extremely cheap direct API ($0.22/M input Flash, $0.44/M Pro; cache hits at $0.004/M)
+- ✅ v4 Pro widely considered better than Claude Opus 4.7 for agentic tasks. "Smarter than Claude Sonnet" — from 6B-token test.
+- ✅ Direct API includes prompt caching (80-90% cache hit rate with repeated tool schemas — absurdly cheap)
+- ✅ Real-world costs: $0.30–$1.30/day for Flash, $2–6/day for Pro, $60 for 8B tokens over 2-3 weeks (u/drwebb)
+- ❌ OpenRouter markup: same model costs 4-5x more through OR resellers
+- ❌ Pricing changes: v4 pricing restructured May 2026; monitor for future changes
+- ❌ China-based; data sovereignty concerns for some users
+- ❌ Throttling/503 errors during US peak hours (single-digit t/s). Community workaround: fallback chain to Flash or another provider.
+- 💡 **Tip:** Use direct API, not OpenRouter. Pin to `api.deepseek.com`. Cache system prompt + tool schemas for massive savings.
+
+### OpenRouter
+- ✅ Access to 200+ models from one account
+- ✅ Built-in fallback chains
+- ✅ owL-alpha on free tier — "absolute beast at tool usage"
+- ❌ Variable per-provider pricing — same model at different price points
+- ❌ Community warns: "avoid silent auto-routing for anything that mutates state"
+- ❌ Default routing can silently switch models mid-task
+- 💡 **Tip:** Pin specific model IDs and set limits. Use as fallback pool + free tier only.
+
+### Nous Portal
+- ✅ $20/mo covers multiple models
+- ✅ First-party integration with Hermes (Nous builds Hermes)
+- ❌ Some models consume extra credits beyond subscription
+- ❌ "Hermes Plus" Opus routing doesn't feel identical to native Claude Code
+- 💡 **Tip:** Check usage dashboard regularly; some users report opaque credit consumption
+
+### OpenAI Codex
+- ✅ GPT-5.5 — "undisputed king" for complex coding
+- ✅ OAuth auth — no API key to leak
+- ❌ Burns weekly rate limits fast if used as primary
+- ❌ Cannot use as pure API key provider; must use OAuth flow
+- 💡 **Tip:** Use as "senior fixer" for hard problems only. Pair with a cheap orchestrator for daily driving.
+
+### Minimax
+- ✅ $10/mo token plan is "virtually unlimited" — 15K req/week
+- ✅ M3 considered "as good as GPT-5.5-low"
+- ❌ M2.7 reliable but uncreative. Prone to looping without guardrails.
+- 💡 **Tip:** Best for background workers. Never worry about token burn on routine tasks.
+
+### OpenCode Go
+- ✅ $10/mo is the single best value subscription. "~$60 API credit for $10 — 6x value."
+- ✅ Access to DeepSeek Flash/Pro, Minimax M3, MiMo 2.5 Pro, GLM, Kimi
+- ❌ Lacks some multimodal models (Gemma 4). Weekly/monthly caps.
+- 💡 **Tip:** Pair with Minimax $10 token plan for a near-unlimited $20/mo stack.
+
+### Anthropic Claude (subscription)
+- ✅ Opus 4.7 excellent for complex reasoning
+- ❌ Subscription path only for Hermes — API key path explicitly forbidden
+- ❌ Community reports of sudden denials for agentic use
+- 💡 **Tip:** If you use Claude, route through OpenRouter instead of direct subscription
+
+### Ollama Cloud
+- ✅ Simple hosted inference for open models
+- ❌ **3 concurrent connection limit** — cron jobs crash if chatting simultaneously
+- ❌ Recently degraded (server busy, slow tokens). No transparency on capacity.
+- 💡 **Tip:** Only use if you specifically need hosted open models and can tolerate the limits.
+
+---
+
+## PART 5: Model Routing & Fallback Chains
+
+### Gold Standard: Two-Tier + Fallback Architecture
+
+This is the pattern used by the most sophisticated Hermes setups (from the 6B-token test thread):
+
+```
+Tier 1 — Orchestrator (cheap + fast, handles 90%):
+  GPT-5.4-mini, DeepSeek v4 Flash, or Kimi K2.6
+  → General chat, routing, web search, lightweight tasks
+
+Tier 2 — Powerhouse (expensive + smart, invoked only when needed):
+  GPT-5.5 (via Codex), DeepSeek v4 Pro
+  → Complex coding, deep research, multi-step synthesis
+
+Fallback chain (when limits hit):
+  GLM-5.1 → Nemotron 3 Super 120B (free) → owL-alpha
+```
+
+Community quote: *"Never use one model for everything. Smart routing buys you 5-10x more capability per dollar than any single subscription. The $10/mo OpenCode Go + proper routing beats any single $20/mo provider hands down."*
+
+### Pattern 2: Multi-provider stack
+```
+Primary: DeepSeek v4 Pro (direct) or GPT-5.5 (Codex)
+Orchestrator/Auxiliary: DeepSeek v4 Flash (direct) or Minimax M3
+Workers: MiMo 2.5 Pro or Kimi K2.6 (OpenCode Go)
+Fallback: owL-alpha or Nemotron (OpenRouter free tier)
+```
+
+### Pattern 3: OpenRouter as fallback pool
+```
+Hermes → pinned model IDs with fixed providers
+Free tier: owL-alpha or Stepfun 3.7 Flash (pennies/day)
+Never: OpenRouter → auto-routing → unknown model
+```
+Community warning: *"I would avoid silent auto-routing for anything that mutates state. The model can change mid-task and you won't know until it breaks."*
+
+### Pattern 4: Profile-level routing (advanced)
+```
+Root profile: pure coordinator → routes to:
+  coder profile → GPT-5.5 (Codex)
+  researcher profile → Gemini 3.1 Pro
+  pm profile → Minimax M3 or DS v4 Pro
+```
+From u/FinancialBandicoot75: "Now my profiles talk to each other."
+
+### Pattern 5: Event-driven (lowest cost)
+Poll cheaply with lightweight watchers. Only wake Hermes when a filter matches, instead of cron-based fixed schedules. Saves tokens on idle polling. Community project: Watchline by u/SinghCoder.
+
+### Pattern 6: LiteLLM proxy (maximum resilience)
+```
+Hermes → LiteLLM → tiered provider pool
+```
+Several community members use LiteLLM for provider-level failover. More setup complexity but maximum resilience.
+
+---
+
+## PART 6: Cost Management
+
+### What the community actually spends (verified from threads)
+
+| Usage Level | Monthly Cost | Typical Setup | Real User Data |
+|-------------|-------------|---------------|----------------|
+| **Light** (occasional tasks) | $0-5 | OpenRouter free tier (owL-alpha) + DeepSeek Flash free | "0 cost, works for simple tasks" |
+| **Budget** (daily, cost-conscious) | $10-15 | OpenCode Go ($10) + Minimax $10 token plan stack | "OpenCode Go = ~$60 credits for $10 — 6x value" |
+| **Moderate** (daily assistant) | $15-30 | DeepSeek Flash daily + Pro for complex tasks | $0.30–$1.30/day Flash; $2-6/day Pro |
+| **Heavy** (all-day coding agent) | $30-60 | DeepSeek v4 Pro direct API + Flash workers | $60 for 8B tokens over 2-3 weeks (u/drwebb) |
+| **Power user** (multi-agent farm) | $60-200 | Multiple subscriptions + direct APIs | "Burning $4-6/day on DS v4 Pro" (u/Blaze6181) |
+
+### Cost horror stories (learn from these)
+
+- *"Burned through $10 in an hour"* — Claude Sonnet via OpenRouter at reseller markup. Switched to DeepSeek Flash, fixed.
+- *"$100 per day for basic queries with Sonnet"* — switched to DeepSeek v4 Flash, problem gone.
+- *"50K+ tokens on every single prompt"* — context bloat from skills/tools; trimming saved 60%.
+- *"Burned through $10 in an hour"* (OpenRouter variant) — DeepSeek via OR at 4-5x markup. Switch to direct API.
+- *"Ollama Cloud 3-connection limit killed my cron jobs"* — background tasks crashed when chatting simultaneously.
+
+### Cost-saving tips (community consensus, ranked by impact)
+
+1. **Use DeepSeek direct, not via OpenRouter.** 4-5x cheaper for the same model. Cache hits at $0.004/M.
+2. **Two-tier routing: cheap orchestrator + expensive powerhouse.** Flash for 90% of tasks, Pro/Codex only for complex work. Saves 5-10x.
+3. **Offload auxiliary tasks to Flash or Minimax.** Compression, title generation, session search don't need Pro.
+4. **Trim your skills and toolsets.** Every enabled tool adds schemas to every prompt.
+5. **Delegate heavy work to subagents on cheaper models.** See delegation patterns.
+6. **Use prompt caching.** DeepSeek direct API caches repeated tool schemas automatically — 80-90% cache hit rate.
+7. **Event-driven over cron polling.** Lightweight watcher → wake Hermes only when needed instead of fixed-schedule burns.
+8. **Minimax $10 token plan for background workers.** "Virtually unlimited" at 15K req/week. Never worry about token burn on routine tasks.
+9. **Set spending caps.** Every provider supports them. The $100 surprise day is preventable.
+10. **OpenCode Go as primary + pay-per-token fallbacks.** Subscription covers steady usage; API keys cover overflow.
+
+---
+
+## PART 7: FAQ
+
+**Q: What's the absolute cheapest way to run Hermes?**
+A: OpenRouter free tier (owL-alpha — "absolute beast at tool usage") + DeepSeek v4 Flash free tier. $0/month. Expect rate limits. Next step up: DeepSeek v4 Flash direct at $0.30–$1.30/day.
+
+**Q: What's the single best value setup for $20/month or less?**
+A: OpenCode Go ($10) + Minimax $10 token plan. You get ~$60 in API credits from Go + "virtually unlimited" agent work from Minimax. Covers 90% of workloads. The most-recommended budget stack across all threads.
+
+**Q: Should I use OpenRouter or direct APIs?**
+A: Direct APIs are cheaper and predictable. OpenRouter adds 4-5x markup on DeepSeek. Use OR only for model experimentation, free tier models (owL-alpha), or as a fallback pool. Never as primary with auto-routing enabled.
+
+**Q: Can I use my ChatGPT/Claude subscription with Hermes?**
+A: ChatGPT Plus → yes, via OpenAI Codex OAuth (GPT-5.5 access). Claude subscription → technically possible but Anthropic explicitly disallows agentic use without API billing. Community consensus: don't risk your Claude account. Use OpenRouter for Claude access instead.
+
+**Q: DeepSeek v4 Pro vs Flash — which for what?**
+A: Pro for main orchestrator (complex reasoning, coding). Flash for workers, auxiliary tasks, title generation, compression. Flash is cheaper and faster; Pro is smarter.
+
+**Q: Is Nous Portal worth $20/mo?**
+A: Yes if you want one bill and multiple models. No if you're comfortable managing direct API keys and want the absolute lowest cost (DeepSeek direct is cheaper).
+
+**Q: How do I avoid burning $50 in a day?**
+A: Set spending caps in your provider dashboard. Use subscription plans for predictable billing. Never leave OpenRouter on auto-routing with expensive models.
+
+**Q: What's the minimum context window for Hermes?**
+A: 64K tokens minimum. Hermes injects tool definitions, skills, memory, and chat history. Below 64K you'll hit context overflow on the first complex task.
+
+**Q: Which model should I use for coding vs general tasks?**
+A: Coding: GPT-5.5 (Codex) or DeepSeek v4 Pro. General tasks/routing: GPT-5.4-mini, DeepSeek v4 Flash, or Kimi K2.6. Use a two-tier setup so you're not burning expensive tokens on simple routing.
+
+**Q: How do I set up fallback chains?**
+A: `hermes config` → fallback_providers, or use credential pools. For advanced routing, community members use LiteLLM as a proxy. See Part 5.
+
+**Q: Which providers support prompt caching?**
+A: DeepSeek (direct API), Anthropic (API), and OpenAI (API). Prompt caching saves 50-90% on repeated tool schema tokens. OpenRouter caching behavior varies by underlying provider.
+
+**Q: OpenCode Go vs Zen — which should I pick?**
+A: Go. Larger model selection, same price. Zen is simpler but gives you fewer models. Community consensus is unanimous: Go is the better deal.
+
+**Q: What model for background/cron agents?**
+A: Minimax M3 ($10/mo token plan — "virtually unlimited") or DeepSeek v4 Flash via OpenCode Go. Never use expensive models for background tasks.
+
+---
+
+## PART 8: Knowledge Table — Every Provider & Plan Mentioned
+
+| Provider | Price (Monthly) | Free Tier | Key Models | Hermes Setup | Watch For |
+|----------|----------------|-----------|-----------|-------------|-----------|
+| DeepSeek (direct) | Pay-per-token | Flash free tier | v4 Pro, Flash, Coder | `hermes model` → DeepSeek | Direct API 4-5x cheaper than OR. US peak throttling. |
+| OpenCode Go | **$10** ($5 first) | No | DeepSeek Flash/Pro, Minimax M3, MiMo 2.5 Pro, GLM, Kimi | `hermes model` → OpenCode Go | **Best value subscription.** Weekly/monthly caps. $60 credit cap. |
+| Minimax | **$10** token plan | No | M3, M2.7 | `MINIMAX_API_KEY` in .env | "Virtually unlimited." 15K req/week. M2.7 uncreative; M3 better. |
+| Nous Portal | $20 | No | Hermes + DeepSeek + Qwen | `hermes auth add nous` | Non-free models exhaust $20 quickly. |
+| OpenAI Codex | $20 | No | GPT-5.5, GPT-5.4-mini | `hermes auth add openai-codex` | OAuth only. Burns rate limits fast. Use as "senior fixer." |
+| Xiaomi MiMo | $6-13 | No | MiMo 2.5, MiMo 2.5 Pro | `XIAOMI_API_KEY` in .env | No caching. Annual plan ~$13/mo for 2.4B tokens. |
+| Kimi/Moonshot | Pay-per-token | No | K2.6, K2.7 | `KIMI_API_KEY` in .env | Best open Hermes main model. Strict quotas. |
+| OpenRouter | Pay-per-token | Free tier ($10 credit) | 200+ models inc. owL-alpha (free) | `OPENROUTER_API_KEY` in .env | 4-5x markup on DS. Pin models. Avoid auto-routing. |
+| Anthropic (sub) | $20 | No | Opus 4.7, Sonnet 4.5 | OAuth via Hermes | Agentic use discouraged. Token hog. |
+| Gemini (Google) | Pay-per-token | Flash free tier | Flash 2.5, Pro 2.5 | `GOOGLE_API_KEY` in .env | OAuth sub risky as BYOK. |
+| GLM / NeuralWatt | Free $5 credit, then PAYG | Yes ($5) | GLM-5.1, GLM-5.2 | Custom endpoint | 5.1 efficient. 5.2 pricier. Painfully slow. |
+| Ollama Cloud | $20-100 | No | Free/open models only | Custom endpoint | 3-connection limit! Degraded recently. |
+| NVIDIA NIM | Free | Yes | Nemotron 3 Super 120B | Custom endpoint | Best emergency fallback. Free. |
+| Grok / superGrok | $10-30 | No | Grok 4.3 | API key or X Premium sub | X Premium gives ~2hrs agent work. API much better. |
+| NanoGPT | $12 | No | Various | — | Not recommended. Slow, low limits. |
+| Qwen OAuth | Subscription | No | Qwen 3.6, Qwen 3.5 | `hermes auth add qwen-oauth` | Newer; fewer data points. |
+| Stepfun AI | Free voucher ($100) | Yes | Stepfun 3.7 Flash | Custom endpoint | Voucher may no longer be offered. |
+| GitHub Copilot | $10/mo | No | GPT-5.4 via Copilot | ACP transport | Separate from ChatGPT Plus. |
+| OpenCode Zen | $10/mo | No | Curated models | `hermes model` → OpenCode Zen | Smaller selection than Go. |
+| Dappnode Nexus | €20/mo (~$22) | No | Kimi K2.6, MiniMax 2.7, DS 3.2, GLM 5, Qwen | Custom endpoint | Private/anonymous models. Good for privacy-conscious. |
+
+---
+
+## Contribute
+
+This megathread is community-maintained. If you spot an error, have pricing updates, or want to add provider data:
+
+- **Comment below** with corrections — include source (your own usage, provider page, etc.)
+- **Corrections welcome, debate welcome.** This is a snapshot of community consensus, not official advice.
+
+**Local/self-hosted models:** See the [Mac/MLX Megathread](https://www.reddit.com/r/hermesagent/comments/1uc7rw5/) and [Local Models Guide](https://www.reddit.com/r/hermesagent/comments/1stiwug/).
+
+---
+*Compiled from 31+ r/hermesagent threads. All prices USD. Last updated June 25, 2026.*
+
+---
+
+## Comment-Sourced Updates
+
+- **MiniMax pricing drift:** multiple commenters reported that the former $10 plan had been replaced by a $20 plan. Prices in the body are historical snapshots and must be checked against the provider before purchase.
+
+- **Caching is route-specific:** commenters reported different cache behavior through direct MiMo access versus OpenRouter. Do not infer direct-provider behavior from one aggregator route.
+
+- **Rankings are community reports:** claims that one premium subscription or model is categorically best remain opinion unless supported by reproducible task-specific evidence.
+
+## Maintaining this guide
+
+Open an issue or pull request with the official source, date checked, Hermes/backend version, and enough reproduction detail to evaluate the change. No referral links, affiliate links, or unsupported promotional claims.

--- a/megathreads/multi-agent-profiles-2026-06.md
+++ b/megathreads/multi-agent-profiles-2026-06.md
@@ -1,0 +1,465 @@
+# Multi-Agent & Profiles Megathread — Hermes Agent (June 2026)
+
+> Community-maintained GitHub version of the Reddit megathread.
+>
+> Original Reddit thread: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/
+>
+> **Snapshot:** Original post preserved and normalized; comment corrections reviewed through July 16, 2026.
+>
+> Time-sensitive prices, quotas, versions, model availability, benchmarks, and third-party project claims remain dated snapshots unless an official source is cited.
+
+---
+
+**LAST UPDATED:** June 21, 2026
+**Sourced from:** 14+ r/hermesagent threads, official Nous docs (profiles, delegation, Kanban, Swarm), GitHub source, community plugins.
+
+# TL;DR — How Do I Run Multiple Agents?
+
+|Decision|Community Pick|Why|
+|:-|:-|:-|
+|Separate work & personal|**Hermes profiles**|Isolated config, memory, sessions, skills — one machine, many agents|
+|Inter-agent communication|**Kanban board** (shared task queue)|Durable, survives restarts, any agent can read/write|
+|One bot, multiple agents|**Telegram topics** (one bot token → multiple profiles via topic routing)|Simpler than multiple bots|
+|Multiple bot tokens|**One bot per profile**|Cleaner isolation if you have the tokens|
+|Subagent delegation|**delegate\_task** for parallel research, code review, multi-file|Not for durable work — use Kanban for that|
+|Agent teams managing themselves|**Kanban + profiles + cron**|Dispatcher spawns workers, they claim tasks, comment to coordinate|
+
+# Part 1: Profiles — The Foundation
+
+Profiles are the primary multi-agent primitive in Hermes. Each profile is a separate Hermes home directory with its own `config.yaml`, `.env`, `SOUL.md`, memories, sessions, skills, cron jobs, and gateway state.
+
+# Quick Start
+
+    # Create a coding agent
+    hermes profile create coder
+    coder setup          # configure API keys, model
+    coder chat           # start chatting
+
+    # Create a research agent cloned from your current config
+    hermes profile create researcher --clone
+
+    # Create a full clone (everything: config, memories, skills, cron)
+    hermes profile create backup --clone-all
+
+# What profiles actually isolate
+
+|Isolated|Shared|
+|:-|:-|
+|config.yaml|Hermes installation (single codebase)|
+|.env (API keys, tokens)|Python venv|
+|SOUL.md (personality)|System tools|
+|Sessions & conversations|Node.js / npm packages|
+|Memory store|Playwright cache|
+|Skills|GPU / hardware|
+|Cron jobs||
+|Gateway state (bot token, PID)||
+
+# Command aliases
+
+Every profile gets auto-generated commands at `~/.local/bin/<name>`:
+
+    coder chat        # = hermes -p coder chat
+    coder gateway start
+    coder skills list
+    coder config set model.default anthropic/claude-sonnet-4
+
+# Different bot tokens per profile
+
+Edit each profile's `.env` with your preferred text editor (for example `nano` on Linux/macOS or Notepad/PowerShell tooling on Windows):
+
+    ~/.hermes/profiles/coder/.env
+    ~/.hermes/profiles/default/.env
+
+**Safety:** If two profiles accidentally use the same bot token, the second gateway is blocked with a clear error naming the conflicting profile.
+
+# Profiles ≠ Sandboxes
+
+Important: Profiles do NOT sandbox the agent on host installs. The agent still has your user's filesystem access. Profiles isolate Hermes state, not OS access.
+
+If you need separate CLI identities per profile:
+
+    # In the profile's config.yaml
+    terminal:
+      home_mode: profile   # Hermes uses {HERMES_HOME}/home as $HOME
+
+Then initialize per-profile `~/.ssh`, `~/.gitconfig`, `gh` auth, etc. inside that profile's home.
+
+# Part 2: Communication Patterns — How Agents Talk to Each Other
+
+# 🥇 Pattern 1: Kanban Board (Shared Task Queue)
+
+The official multi-agent coordination primitive. A durable SQLite-backed task board shared across all profiles.
+
+    # Create a task for the coder profile
+    hermes kanban create "Fix login timeout bug in auth.py" --assignee coder
+
+    # Agent picks it up, works, updates status
+    hermes kanban show <task-id>    # see comments, status, workspace
+
+    # Human intervention
+    hermes kanban comment <task-id> "Check the edge case at line 47"
+    hermes kanban block <task-id> --reason "Waiting for staging deploy"
+    hermes kanban unblock <task-id>
+
+**Why Kanban beats delegate\_task for durable work:**
+
+|Criterion|delegate\_task|Kanban|
+|:-|:-|:-|
+|Durability|Lost if parent is interrupted|Durable; survives restarts|
+|Human in loop|Not supported mid-task|Supported via comments, block/unblock, reassignment|
+|Multiple agents per task|One subagent per delegated job|Multiple profiles can claim, hand off, and comment over time|
+|Audit trail|Easy to lose after compression/session churn|Comments/status/workspace history stay on the board|
+|Resumability|None — failed = failed|Reclaim stale claims, unblock, reassign, continue|
+
+**Kanban + profiles = a team:**
+
+* Research agent reads docs, writes findings as comments
+* Coder agent picks up the task, implements based on findings
+* Review agent claims next, runs tests, comments review notes
+* Human approves or sends back with a comment
+
+# 🥈 Pattern 2: delegate_task (Parallel Research & Code Review)
+
+For short, reasoning-heavy tasks where the parent needs results immediately.
+
+    delegate_task(tasks=[
+        {
+            "goal": "Research WebAssembly outside the browser",
+            "context": "Focus on: runtimes (Wasmtime, Wasmer), cloud/edge use cases",
+            "toolsets": ["web"]
+        },
+        {
+            "goal": "Research RISC-V server chip adoption",
+            "context": "Focus on: shipping server chips, cloud providers adopting",
+            "toolsets": ["web"]
+        }
+    ])
+
+**What delegate\_task can't do:** survive restarts, involve humans mid-task, coordinate between agents over time. For those, use Kanban.
+
+# 🥉 Pattern 3: Telegram Topics (One Bot, Multiple Profiles)
+
+Route different Telegram topics to different Hermes profiles using a single bot token:
+
+* Topic 1 (Personal) → default profile
+* Topic 2 (Work) → work profile
+* Topic 3 (Coding) → coder profile
+
+Enable topic creation in BotFather, then configure topic routing in Hermes gateway.
+
+Community note: "Telegram with threads on DM. Works like a charm. Just need to enable thread creation on BotFather and you're good to go. Just send /topic and..." — from messaging megathread
+
+# Pattern 4: The Constitution Pattern (Community-Invented)
+
+From u/codexshaper and others: Write a "constitution document" that defines each profile's specialty, capabilities, and routing rules. The orchestrator agent reads this document and routes work accordingly.
+
+    # constitution.md
+    ## Agent: coder
+    - Specialty: Python, JavaScript, system scripts
+    - Tools: terminal, file, github
+    - Route: any coding, debugging, or implementation task
+
+    ## Agent: researcher
+    - Specialty: web research, docs reading, API exploration
+    - Tools: web, file
+    - Route: any research, documentation, or discovery task
+
+    ## Agent: reviewer
+    - Specialty: code review, security audit, test coverage
+    - Tools: terminal, file, github
+    - Route: any review, audit, or quality task
+
+Then in your orchestrator's SOUL.md: "Read constitution.md before routing any task. Delegate to the profile whose specialty matches."
+
+# Pattern 5: Multi-Agent Context Plugin (Community-Built)
+
+From u/kaishi00: A Hermes plugin that injects chat history into each agent's context during their turn so they know what's happening in a shared channel. Supports Telegram.
+
+    # Install on each profile:
+    git clone https://github.com/kaishi00/hermes-community-plugins
+
+**Critical config:** "make sure it require mentions" — without this, agents will talk to each other endlessly. Multiple users reported waking up to agents that had been conversing all night.
+
+**Gateway config requirement:** On Discord, bots ignore mentions from other bots by default. You must update the gateway config to allow bot-to-bot mentions. On Telegram, bots need admin access in group chats (this is a Telegram limitation, not Hermes-specific — non-admin bots can only respond to slash commands or ping mentions).
+
+# Pattern 6: Shared Memory / Context Bus
+
+Advanced patterns from community builds:
+
+* **A2A Context Bus** (u/ihgrant): A message-passing system where agents publish context updates to a shared bus, other agents subscribe and pull relevant context. Built as a Hermes plugin/skill.
+* **Shared Kanban board with comments**: Agents use Kanban comments as an inter-agent protocol — each comment is visible to the next agent that picks up the task.
+* **Honcho memory + profiles**: When Honcho is enabled, profile clones automatically create dedicated AI peers sharing the same user workspace while building independent observations.
+* **NAS Shared Log** (u/Fun_Firefighter_7785): For agents on different physical machines. Uses append-only `.log` files with `fcntl.flock()` advisory locking over CIFS/NFS. Mount with `actimeo=0` for real-time sync. Critical finding: SQLite over network shares silently fails — file locks are advisory only. The text-log approach with proper locking is the reliable path.
+* **agentsocket.dev**: A WebSocket-based agent communication service. Create a group chat via agent-socket, share the connect link with other agents.
+
+# Pattern 7: Direct Agent-to-Agent via Telegram/Discord
+
+Create a dedicated Telegram group or Discord channel where agents post to each other. Each agent has its own bot token in the group. Agents @mention each other, read messages, and respond.
+
+**Critical gateway configs:**
+
+* Discord: Bots ignore other bot mentions by default — update gateway config to allow bot-to-bot mentions
+* Telegram: Bots need admin access for full functionality; non-admin bots can only respond to slash commands or ping mentions
+
+Community caution from multiple users: This pattern can lead to agent loops and token waste. "I woke up one morning to two of my agents complaining all night about how they hadn't heard from me in several hours" — u/thetomsays (+26). Use mention-required mode and circuit breakers.
+
+# Part 3: The Community's Real Setups
+
+# The "Orchestrator + Specialists" Org Chart
+
+The most common pattern across threads:
+
+                     ┌─────────────┐
+                     │ Orchestrator │  (default profile)
+                     │  (FRIDAY)    │  Reads constitution, routes tasks
+                     └──────┬──────┘
+              ┌─────────────┼─────────────┐
+              │             │             │
+        ┌─────┴─────┐ ┌─────┴─────┐ ┌─────┴─────┐
+        │   Coder   │ │ Researcher│ │  Personal │
+        │  profile  │ │  profile  │ │  profile  │
+        └───────────┘ └───────────┘ └───────────┘
+
+Each specialist has:
+
+* Its own SOUL.md defining its role
+* Restricted toolset (coder gets terminal+file+github, researcher gets web+file)
+* Its own gateway (Telegram topic or separate bot)
+* Tasks arrive via Kanban board or direct delegation
+
+# The 4-Tier Scaling Model
+
+From u/nemanja87mn (+20) — the community's definitive scaling framework:
+
+|Tier|Setup|When to Use|
+|:-|:-|:-|
+|**Tier 1**|One agent, one gateway, delegate\_task for subagents|Protecting context without adding complexity|
+|**Tier 2**|Orchestrator + specialist profiles, one chat surface|Multiple roles, isolated memory, one Telegram/Discord|
+|**Tier 3**|Domain orchestrators with separate bots|Different businesses/domains (investment, coding, family)|
+|**Tier 4**|Separate instances (same machine or VPS)|Client work, production, strict isolation|
+
+**Key insight:** Most people never need Tier 3 or 4. "Start with a single agent and create as needed" — u/laffytaffykidd (+12).
+
+# The Constitution Pattern (Community-Invented)
+
+From u/Starrwulfe (+3) — collapse multiple profiles into one agent with split personalities:
+
+>"Chances are those five agents can be one agent in Hermes that has five split personalities. Those split personalities can then be sub delegated to without you even having to do anything, even set up a profile."
+
+How it works:
+
+1. Create skill files in separate folders under the Hermes home directory
+2. Each skill defines one "personality" — its specialty, tools, tone
+3. Draft a `constitution.md` that maps specialties to personalities
+4. The orchestrator reads the constitution before routing any task
+5. delegate\_task launches the appropriate personality as a subagent
+
+**Result:** "I went from having three separate agents and four profiles to having one agent with eight personalities and it's way more efficient." Profiles are powerful but sometimes overkill — a well-structured single agent with constitution-based routing can handle multiple domains cleanly.
+
+# The Gradual Approach
+
+From u/selipso (+3) — don't build the org chart on day one:
+
+>**Week 1:** One gateway, two profiles (default + one specialized). Turn off all skills on the specialized profile except the ones you need (\~15-20 skills). Set up memory layer. Chat with it. Don't add tools.
+
+>**Week 2+:** If context pollution occurs, add another profile. "Hermes takes about a week to fully settle into its role."
+
+# The "Agent That Sets Up Agents" Meta-Pattern
+
+From u/MrOzanges (+1): Ask your main Hermes agent to create a profile specifically for setting up other profiles. That specialist agent reviews SOUL.md, disables irrelevant tools/skills, and configures new profiles optimally. Meta: your agent architects your agent team.
+
+# The Swarm Master Pattern
+
+From u/mitchells00 (+1): A Hermes gateway whose job is commissioning new Hermes gateways — each a multi-profile swarm in its own Docker container. Limitation noted: "I'm hitting limits with how you cannot specify which agent profiles are relevant for which kanban boards."
+
+# Hermes Swarm (Official)
+
+A built-in feature for simultaneous multi-model queries (similar to Grok's approach). Multiple models process the same query in parallel; results are combined into a hybrid answer. Less documented than Kanban/delegation but exists as a distinct feature. Community awareness is low — when mentioned, most users haven't tried it.
+
+# Real community setups:
+
+**"I gave my Hermes team a shared Kanban board. Now they manage themselves."** — u/Ok_Run_5401
+
+* Created a third-party Kanban board project (`pip install hermes-kanban`, github.com/amirghm/hermes-kanban) with auto-discovery of Hermes profiles
+* Agents auto-appear from profiles — reads SOUL.md for name/description
+* Includes an Agent-to-Agent (A2A) protocol for direct inter-agent messages
+* Community response was split: many noted Hermes already has a **built-in native Kanban** (accessible via web dashboard and desktop app), while others appreciated the Telegram integration and simpler UI
+* OP's take: "I know, but I designed a simpler one that suits my needs"
+* **Recommendation:** Start with Hermes' built-in Kanban (zero setup, integrated with profiles and the dispatcher). Consider third-party tools only if you need specific features the native board doesn't offer (e.g., Telegram-native task management, custom A2A protocols).
+* **Note:** This post showed signs of self-promotion — the OP's account had multiple recent posts promoting repos. Evaluate project links critically. The built-in Kanban is the supported path.
+
+**"CrewAI/AutoGen aren't cutting it" thread resolution:**
+The OP moved from CrewAI/AutoGen to Hermes profiles because:
+
+* Profiles give persistent memory per agent (CrewAI agents lose context between runs)
+* Kanban provides durable coordination (AutoGen's in-process handoffs are fragile)
+* One machine runs all agents (CrewAI/AutoGen expect separate deployments)
+* Community solution: delegate\_task + Engram shared memory + OpenClaw for execution: *"I'm just using a skill with --delegate-task from Hermes to openclaw and a shared memory through Engram system... Nothing is installed apart from that, all built using Hermes."* — u/djenttleman
+
+**"Best Way to Separate Personal from Work and Telegram"** — u/harpr1t
+
+* Default profile = personal agent (one Telegram bot)
+* Work profile = work agent (separate Telegram bot)
+* Docker on NAS running both
+* Key learning: two bots = cleanest separation. Topics work but bots are simpler for strict separation.
+
+# Part 4: Kanban Deep Dive
+
+# The dispatcher
+
+The Kanban dispatcher runs inside the Hermes gateway and polls every N seconds (default 60):
+
+1. Reclaims stale claims (agent died mid-task)
+2. Promotes ready tasks (all parent tasks done → promote)
+3. Spawns assigned profiles as workers
+4. Workers get `kanban_*` tools to interact with the board
+
+# Workspace types
+
+|Type|Use Case|Persistence|
+|:-|:-|:-|
+|`scratch`|One-off tasks|Deleted on completion|
+|`dir:<path>`|Ongoing work in a real directory|Preserved|
+|`worktree`|Git worktree for coding|Preserved|
+
+# Multi-board
+
+For separate projects, create separate boards:
+
+    hermes kanban boards create project-alpha --name "Project Alpha"
+    hermes kanban --board project-alpha create "Add payment integration" --assignee coder
+
+# Kanban vs delegate_task — when to use which
+
+    Use delegate_task when:              Use Kanban when:
+    - Parent needs answer to continue    - Work crosses agent boundaries
+    - No humans involved                  - Might need human input
+    - Result goes into parent's context   - Needs to survive restarts
+    - Short reasoning task (<50 turns)    - Multiple agents over task lifetime
+    - Parallel research or code review    - Scheduled recurring work
+
+# Part 5: Delegation Patterns (from Official Docs)
+
+# Parallel Research
+
+    delegate_task(tasks=[
+        {"goal": "Research topic A", "toolsets": ["web"]},
+        {"goal": "Research topic B", "toolsets": ["web"]},
+        {"goal": "Research topic C", "toolsets": ["web"]}
+    ])
+
+# Code Review
+
+    delegate_task(
+        goal="Review src/auth/ for security issues",
+        context="Project at /home/user/webapp. Python 3.11, Flask. Files: src/auth/login.py, src/auth/jwt.py. Test: pytest tests/auth/ -v",
+        toolsets=["terminal", "file"]
+    )
+
+# Multi-File Refactoring
+
+Split files across parallel subagents. Each gets separate terminal session. Don't let two subagents touch the same file.
+
+# Gather Then Analyze
+
+Use `execute_code` for mechanical data gathering (10+ tool calls cheaply), then `delegate_task` for the single expensive reasoning step with clean context.
+
+# Critical: The Context Problem
+
+Subagents know NOTHING about your conversation. Always pass explicit file paths, error messages, and constraints.
+
+# Part 6: Common Pitfalls
+
+# Pitfall 1: Profiles ≠ Sandboxes
+
+"I thought creating a 'work' profile would isolate my work files from my personal agent." — Profiles isolate Hermes state, not filesystem access. Use Docker, VMs, or `terminal.home_mode: profile` for filesystem isolation.
+
+# Pitfall 2: Agent-to-Agent Loops
+
+Multiple agents talking to each other via Telegram/Discord can create infinite loops. Always set circuit breakers: `tool_loop_guardrails.hard_stop_enabled: true` with reasonable limits.
+
+# Pitfall 3: Mixed Bot Tokens
+
+If two profiles accidentally share a Telegram bot token, the second gateway gets blocked. Check `~/.hermes/profiles/<name>/.env` for each profile.
+
+# Pitfall 4: Delegate_task for Durable Work
+
+"Created a research task via delegate\_task, my laptop went to sleep, lost everything." — delegate\_task is synchronous. For durable work, use Kanban or cronjob.
+
+# Pitfall 5: `SOUL.md` Changes in Active Sessions
+
+Changes to SOUL.md take effect on NEW sessions only. If you change SOUL.md mid-conversation, the agent won't see it until /new.
+
+# Pitfall 6: Confusing HERMES_HOME with Working Directory
+
+Setting terminal.cwd does NOT set the profile boundary. The profile boundary is HERMES\_HOME. Working directory is separate.
+
+# Part 7: FAQ
+
+**Q: How do I separate work and personal agents?**
+A: Create separate profiles: `hermes profile create work --clone`. Give each its own Telegram bot token. Or use Telegram topics with a single bot routed to different profiles.
+
+**Q: Can agents talk to each other directly?**
+A: Not natively like a group chat. The closest patterns are: (1) Kanban comments as inter-agent protocol, (2) Telegram group with multiple bot tokens, (3) A2A Context Bus plugin. Direct agent-to-agent conversation is not a built-in Hermes feature.
+
+**Q: Should I use profiles or delegate\_task?**
+A: Profiles = persistent agents with memory and identity. Delegate\_task = disposable subagents for one-off reasoning. They're complementary — profiles are the team, delegate\_task is consulting an expert for a quick opinion.
+
+**Q: How many profiles can I run?**
+A: No hard limit. Each profile is just a directory. Resource limits are the real constraint — each gateway consumes memory. Docker users: one container supervises all profiles via s6-overlay.
+
+**Q: Can I delegate a task to a different profile?**
+A: delegate\_task spawns anonymous subagents using the current model — NOT named profiles. This is a known limitation. At least 4 PRs have been opened to add a `profile` parameter to delegate\_task, but none have been merged as of June 2026 (earliest PR is 2+ months old — #6771). Workarounds: (1) Use Kanban (create task → assignee picks it up), (2) Use auxiliary model config for specific tasks (e.g., set a vision model as `auxiliary.vision`), (3) The constitution pattern (orchestrator reads constitution, manually routes), (4) Instruct the agent to call `hermes -p <profile> chat -q "..."` from the CLI (messy but works).
+
+**Q: How do I share memory across profiles?**
+A: Honcho memory provider shares a user workspace across profiles by default. Each profile builds independent observations. For custom sharing, use a shared Obsidian vault, shared files, or Kanban comments as context transfer.
+
+**Q: What are profiles NOT good for?**
+A: Profiles are not containers. If you need strict filesystem isolation between agents, use separate Docker containers, VMs, or machines.
+
+**Q: Can one Telegram bot serve multiple profiles?**
+A: Yes — via Telegram topics. Each topic routes to a different profile. Enable topics in BotFather, configure routing in gateway config. Simpler than managing multiple bot tokens.
+
+**Q: My agents keep getting stuck in loops when coordinating. What do I do?**
+A: Enable hard stops: `tool_loop_guardrails.hard_stop_enabled: true` with `hard_stop_after.exact_failure: 5`. Also set Kanban failure limits (`kanban.failure_limit`) to prevent thrashing on broken tasks.
+
+# Part 8: Knowledge Table — Every Tool & Pattern
+
+|Name|Type|Best For|Watch For|
+|:-|:-|:-|:-|
+|**Profiles**|Multi-agent primitive|Persistent agents with identity|Not filesystem sandboxes|
+|**Kanban**|Task queue|Durable multi-agent coordination|Dispatcher runs in gateway|
+|**delegate\_task**|Subagent spawn|Parallel research, code review|Not durable; lost on restart|
+|**Telegram Topics**|Message routing|One bot → multiple profiles|Needs BotFather topic setup|
+|**Constitution Pattern**|Community invented|Orchestrator routing rules|Manual setup, no built-in tool|
+|**A2A Context Bus**|Community plugin|Agent message passing|Custom build required|
+|**Honcho Memory**|Memory provider|Shared memory across profiles|Setup complexity|
+|**Kanban Comments**|Inter-agent protocol|Agent-to-agent handoff|Agents must be instructed to read|
+|**Kanban Workspaces**|Task isolation|Per-task directories|Scratch dirs deleted on completion|
+|**Multiple Bot Tokens**|Gateway isolation|Strict agent separation|More tokens to manage|
+
+# Part 9: The Bottom Line
+
+Hermes profiles + Kanban form a genuine multi-agent operating system — not a chatbot with a "team mode" gimmick. Each profile is a persistent agent with its own memory, skills, and identity. Kanban gives them a shared work queue that survives crashes and restarts.
+
+The community is actively graduating from single-agent setups to agent teams: orchestrator + specialists pattern, shared boards with self-management, and increasingly sophisticated coordination via comments and context buses.
+
+Start simple: create one extra profile, give it a different SOUL.md, connect it to a Kanban board. Watch how the orchestrator naturally starts routing tasks.
+
+*Synthesized from 8+* r/hermesagent *threads, official Hermes profiles documentation, delegation patterns guide, Kanban specification, and community-reported setups. Corrections and additions welcome.*
+
+---
+
+## Comment-Sourced Updates
+
+- **Profiles are not sandboxes:** they isolate configuration, sessions, memory, and credentials; ordinary filesystem permissions still apply.
+
+- **Delegation is not durable scheduling:** a background child tied to the parent session can be lost when that session closes. Use Kanban or another tracked durable mechanism for work that must survive interruption.
+
+- **Table repair:** the Reddit rendering obscured a comparison-table column. This source copy should be reviewed as profiles/runtime overrides/delegation/Kanban—not as interchangeable mechanisms.
+
+- **Avoid profile proliferation:** runtime model overrides and one-shot profile commands often solve temporary routing needs without creating another permanent identity.
+
+## Maintaining this guide
+
+Open an issue or pull request with the official source, date checked, Hermes/backend version, and enough reproduction detail to evaluate the change. No referral links, affiliate links, or unsupported promotional claims.

--- a/megathreads/qwen3.6-27b-community-variants-2026-07.md
+++ b/megathreads/qwen3.6-27b-community-variants-2026-07.md
@@ -1,0 +1,98 @@
+# Qwen3.6-27B Community Variants — Historical Guide for Limited Hardware
+
+> Community-maintained GitHub version of the Reddit megathread.
+>
+> Original Reddit thread: https://www.reddit.com/r/hermesagent/comments/1tn4lye/qwen3627b_community_variants_the_definitive_guide/
+>
+> **Repository edition:** July 16, 2026
+> **Original post snapshot:** May 24, 2026
+
+This guide preserves the original post’s variant-selection framework without treating historical download counts, benchmark results, throughput figures, or “best model” rankings as current facts.
+
+## Verification boundary
+
+Before downloading any variant, verify:
+
+- current model-card URL, owner, lineage, and license;
+- exact quant filename and size;
+- supported backend and version;
+- tool-calling, vision, thinking, and context behavior;
+- memory requirements at your intended context and KV-cache format;
+- benchmark method, hardware, flags, and capture date.
+
+## Base model and variant families
+
+The original post grouped derivatives into several broad families.
+
+### Safety-removal and heretic-style variants
+
+Repositories mentioned by the source include DavidAU, HauhauCS, huihui-ai, and other community conversions. Safety-removal claims such as “uncensored,” “lossless,” refusal counts, or “same as base” are publisher/community descriptions that require independent testing.
+
+The original post highlighted a DavidAU Heretic/NEO-CODE derivative as a community favorite. Treat that as a dated recommendation, not a verified ranking.
+
+### Reasoning-distilled variants
+
+The source discussed derivatives trained on reasoning traces, including rico03 and related Opus-distilled variants. Distillation may change verbosity, repetition, coding behavior, tool-call reliability, and long-context behavior.
+
+### Abliterated variants
+
+Abliteration attempts to alter refusal behavior through weight-space edits. It can affect capability and stability. Compare against the base model on the same task set before deployment.
+
+### MTP and speculative decoding
+
+Runtime support evolved quickly during the source discussion. Verify current llama.cpp/LM Studio/backend support rather than relying on the historical branch status or launch flags.
+
+## Hardware selection framework
+
+Model-file size is only part of the footprint. Account for:
+
+- KV cache at the intended context;
+- runtime overhead;
+- vision projector;
+- MTP/draft head;
+- concurrent slots;
+- CPU offload and system RAM;
+- other models sharing the host.
+
+### 16 GB-class systems
+
+The comments generally discouraged forcing a 27B model into a 16 GB Mac for sustained agent work. Very low-bit quants may load but can sacrifice reliability and leave little context headroom. Compare with a remote API.
+
+### 24 GB-class systems
+
+A moderate quant may leave enough headroom for a useful context and runtime overhead. Do not assume another user’s tokens-per-second result will transfer across backend, context, or cache settings.
+
+### Larger-memory systems
+
+Use the headroom for context, cache precision, or a less aggressive quant. Recalculate memory for the actual Hermes workload rather than the model file alone.
+
+## Hermes validation checklist
+
+Test each candidate with the same repeatable workflow:
+
+1. harmless read-only tool call;
+2. multi-step file task in a sandbox repository;
+3. malformed-path recovery;
+4. long tool output and context compression;
+5. structured tool-call output;
+6. vision test, if applicable;
+7. long-context retrieval test;
+8. MTP on/off comparison on identical prompts.
+
+Record the model ID, quant, backend version/commit, flags, hardware, context, cache type, and date.
+
+## Publisher controversy
+
+The comments contain serious allegations concerning one publisher and model quality. This repository does not treat those allegations as established fact. The companion provenance file keeps a neutral summary and source link. Any canonical warning should be based on primary repository history, license evidence, attributable benchmarks, or reproducible model comparisons.
+
+## Comment-Sourced Updates
+
+- **Context assumptions matter:** quant and memory advice must state the context and KV-cache format.
+- **16 GB warning:** a remote/API model may be more practical than an aggressively compressed 27B local model.
+- **Benchmarks are dated reports:** “best variant,” speed, and quality claims require reproducible methodology.
+- **Launch configurations are examples:** backend flags and quant names change; verify current documentation.
+- **Reputational claims remain unverified:** preserve evidence neutrally and provide alternatives.
+
+## Maintaining this guide
+
+Open an issue or pull request with the exact model-card URL, lineage/license, quant filename, backend version, hardware, context/cache settings, test method, and date. No referral links, affiliate links, unsupported promotion, or unsourced allegations.

--- a/megathreads/qwen3.6-35b-a3b-community-variants-2026-07.md
+++ b/megathreads/qwen3.6-35b-a3b-community-variants-2026-07.md
@@ -1,0 +1,170 @@
+# Qwen3.6-35B-A3B Community Variants — Historical Guide for Limited Local Hardware
+
+> Community-maintained GitHub version of the Reddit megathread.
+>
+> Original Reddit thread: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/
+>
+> **Repository edition:** July 16, 2026
+> **Original post snapshot:** May 24, 2026
+
+This guide preserves the useful selection framework from the original post without presenting its historical download counts, benchmark scores, throughput figures, or quality rankings as current facts.
+
+## Verification boundary
+
+Before downloading a variant, verify all of the following on the current model card and runtime release:
+
+- repository owner, model lineage, and license;
+- exact quant filename and file size;
+- backend compatibility and required build;
+- vision, thinking, tool-calling, and MTP support;
+- context length and KV-cache memory at the context you intend to use;
+- benchmark methodology, hardware, flags, and capture date.
+
+The original Reddit post contains detailed historical figures. Those remain available through the source link, while comment claims are classified in the companion provenance file.
+
+## Base model
+
+The variant family discussed here is built around `Qwen/Qwen3.6-35B-A3B`.
+
+Official model card to check first:
+
+- https://huggingface.co/Qwen/Qwen3.6-35B-A3B
+
+The source post described it as a mixture-of-experts model with multimodal support and a large native context window. Use the official model card—not the historical Reddit figures—for current architecture and benchmark details.
+
+## What community variants change
+
+### Safety-removal and abliteration
+
+These variants attempt to reduce refusals through weight-space edits or related techniques. “Uncensored,” “lossless,” and refusal-count claims are publisher/community descriptions, not guarantees of unchanged capability.
+
+Community repositories mentioned in the source post include:
+
+- `HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive`
+- `LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF`
+- `llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF`
+- `huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated`
+- mradermacher Abliterix/EGA conversions
+
+Treat each as a separate derivative. Review its license, conversion notes, evaluation method, and upstream lineage before use.
+
+### Reasoning-distilled variants
+
+These variants were described as fine-tuned on reasoning traces from larger models. Distillation can change reasoning style, verbosity, repetition, coding behavior, vision quality, and tool-call reliability.
+
+Repositories mentioned in the source post include:
+
+- `Jackrong/Qwopus3.6-35B-A3B-v1-GGUF`
+- `lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled`
+- `hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF`
+- `huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated`
+
+The original post’s comparative quality and speed statements were not independently reproduced during migration. Test candidates with your own Hermes tasks and tool schemas.
+
+### APEX conversions
+
+The source post described APEX as a mixture-of-experts-oriented quantization approach rather than a new base model. It mentioned base, reasoning-distilled, and MTP-enabled APEX conversions from the LocalAI/mudler ecosystem.
+
+Examples named in the source post:
+
+- `mudler/Qwen3.6-35B-A3B-APEX-GGUF`
+- `mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF`
+- reasoning-distilled APEX/MTP conversions
+- `mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF`
+
+Verify that the current runtime supports the exact quantization format before downloading.
+
+### MTP and speculative decoding
+
+Multi-Token Prediction support changed while the Reddit discussion was active. The original post referred to a custom llama.cpp build; commenters later reported support reaching a newer llama.cpp branch.
+
+Current rule:
+
+1. Check the current llama.cpp release notes or branch documentation.
+2. Confirm that the exact model contains a compatible MTP head.
+3. Confirm whether vision, parallel decoding, and your chosen cache format work with that build.
+4. Benchmark with and without MTP on the same prompt set and context.
+5. Do not assume a speedup or unchanged quality from another user’s hardware.
+
+MTP-related repositories mentioned in the source post include Unsloth, havenoammo, byteshape, llmfan46, huihui, and mudler conversions.
+
+DFlash was described as a separate draft-model approach rather than a standalone chat model. Verify current runtime support and training status before considering it.
+
+## Hardware selection framework
+
+Do not select a model by GPU VRAM alone. Estimate the complete runtime footprint:
+
+- quantized model file;
+- KV cache at the intended context;
+- vision projector, if used;
+- MTP or other draft head;
+- runtime and CUDA/Metal/ROCm overhead;
+- concurrent slots;
+- CPU offload and system RAM headroom.
+
+### Very constrained systems
+
+Low-bit quants may fit, but capability and tool-call reliability can degrade sharply. Keep context modest, test the real Hermes tool loop, and compare against a remote API before committing to the local route.
+
+### Mid-range systems
+
+Choose a quant that leaves headroom for cache and runtime overhead instead of selecting the largest file that barely loads. Mixture-of-experts CPU offload may help, but it changes latency and throughput.
+
+### Higher-memory systems
+
+Use the additional headroom for context, cache precision, or a less aggressive quant. Larger context still requires explicit memory planning; the model file fitting does not prove the agent workload will fit.
+
+## Hermes-specific validation
+
+Before making a variant your primary model, run a small repeatable suite:
+
+1. list tools and call a harmless read-only tool;
+2. perform a multi-step file task inside a sandbox repository;
+3. test malformed-path and missing-file recovery;
+4. test context compression and a long tool result;
+5. verify structured output or tool-call JSON;
+6. test vision separately if the variant claims multimodal support;
+7. repeat the same suite with thinking enabled and disabled;
+8. compare MTP on and off using identical prompts.
+
+Record the model ID, quant, backend commit/release, flags, hardware, context, cache type, and date.
+
+## Tool-loop troubleshooting lead
+
+Commenters associated repeated tool calls with `Preserve_thinking` and `Enable_thinking` behavior on some model-card/runtime combinations. That is a troubleshooting lead, not a universal fix.
+
+If loops occur:
+
+- reproduce with one simple tool;
+- inspect the raw tool-call payload;
+- test thinking on and off;
+- reduce ambiguous instructions;
+- verify timeout/retry behavior;
+- compare a different quant or base variant;
+- confirm the same task works on a known-good model.
+
+## Publisher controversy
+
+The comment thread contains accusations and counterclaims concerning one variant publisher. This repository does not adjudicate them. The provenance notes retain neutral summaries and source links. Anyone proposing a warning or removal should provide primary repository history, license text, commits, and attributable evidence.
+
+## Comment-Sourced Updates
+
+- **MTP status changed during publication:** do not follow the original custom-build statement without checking the current runtime.
+- **Thinking/tool loops:** thinking-related settings were reported as a possible contributor on some builds; reproduce before changing defaults.
+- **Performance claims:** speedups, timeout values, context recommendations, and benchmark tables are dated community reports.
+- **Quant guidance:** verify the exact filename on the current model repository; similarly named IQ/K quants are not interchangeable.
+- **Reputational claims:** allegations and defenses remain unverified and are excluded from canonical recommendations.
+
+## Maintaining this guide
+
+Open an issue or pull request with:
+
+- exact model-card URL;
+- lineage and license;
+- quant filename;
+- backend and version/commit;
+- hardware, context, cache, and flags;
+- reproducible prompt or benchmark method;
+- date tested.
+
+No referral links, affiliate links, unsupported promotional claims, or unsourced allegations.

--- a/megathreads/vps-deployment-2026-06.md
+++ b/megathreads/vps-deployment-2026-06.md
@@ -1,0 +1,399 @@
+# VPS & Deployment Megathread — Hermes Agent (June 2026)
+
+> Community-maintained GitHub version of the Reddit megathread.
+>
+> Original Reddit thread: https://www.reddit.com/r/hermesagent/comments/1ucke01/vps_deployment_megathread_hermes_agent_june_2026/
+>
+> **Snapshot:** Original post preserved and normalized; comment corrections reviewed through July 16, 2026.
+>
+> Time-sensitive prices, quotas, versions, model availability, benchmarks, and third-party project claims remain dated snapshots unless an official source is cited.
+
+---
+
+**LAST UPDATED:** June 21, 2026
+**Sourced from:** 9+ r/hermesagent threads (200+ comments), official Nous docs, GitHub raw docs, external deployment guides, and the Hermes Dockerfile source.
+
+---
+
+## TL;DR — What Should I Do?
+
+| Decision | Community Pick | Runner-Up | Key Factor |
+|----------|---------------|-----------|------------|
+| Deployment type | **Bare metal on dedicated machine** | VM with snapshots (Proxmox) | Docker adds friction for most |
+| VPS provider | **Hetzner** (€4-8/mo) | Netcup ($10-13/mo), Oracle free tier | Avoid Hostinger — affiliate hype |
+| Remote access | **Tailscale** (mesh VPN) | Cloudflare Tunnel + auth | Zero open ports > port forwarding |
+| Local alternative | **Used Dell Optiplex / Mini PC** | Raspberry Pi 5 (8GB) | $100-400 one-time vs $10-30/month |
+| Docker choice | **Avoid for active dev** | Use for stable production only | Exploration = VM; stability = Docker |
+
+---
+
+## Part 1: The Deployment Landscape
+
+### 🥇 Tier 1: Bare Metal / Root Install (Community Favorite)
+
+**What it is:** Install Hermes directly on the OS — no Docker, no VM layer. `curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash`
+
+**Why the community prefers it:**
+- Hermes has full filesystem access — can install tools, manage services, fix system issues
+- No Docker permission headaches, no volume mount confusion, no missing dependencies
+- "Hermes needs more than a container to run optimally. It needs an entire tech stack." — u/Shady_Prospector
+- "I want it to run free like a lion in Africa" — u/PurpleParrot1999
+- Direct access means Hermes can fix real problems: one user described Hermes diagnosing a dual-starting systemd service with zero config — "no need to link drives, give temporary access rights, just straight: 'check why this service runs twice', and it fixed it"
+
+**Watch for:**
+- Security: Hermes has full access to your machine. Use a dedicated box or VM.
+- Backups: Snapshot or back up ~/.hermes regularly. "The very second I got my Hermes config to a workable state I snapshot that MF" — u/100PercentJake
+- Log rotation: Session logs and SQLite state.db fill disks fast on active use (u/Profanonyme1337)
+- Systemd on Linux: `hermes gateway install --system` for auto-start on boot, clean restarts, proper logging
+- Launchd on macOS: `hermes gateway install` handles this
+
+**Best for:** Active development, tinkering, local-only setups, anyone who wants Hermes to manage the machine
+
+---
+
+### 🥈 Tier 2: VM with Snapshots (Sanity Saver)
+
+**What it is:** Run Hermes in a virtual machine — Proxmox, QEMU/KVM, VirtualBox, UTM, VMware. Give it root inside the VM.
+
+**Why:**
+- Full OS access inside the VM, isolation from host
+- Snapshots are the killer feature: break something? Revert in seconds
+- "I prefer the hypervisor route because I can right click and hit 'snapshot' and have something to go back to" — u/100PercentJake
+- Proxmox is the most-cited hypervisor across threads
+- Works on everything: old laptops, N100 mini PCs, Synology NAS, Dell Optiplex
+
+**Best for:** People who want isolation but not Docker restrictions, anyone who tinkers heavily and needs rollback
+
+**Watch for:**
+- RAM overhead: host OS + VM eats RAM. One user moved from VM to bare metal because "half my system's RAM was [used by] the host OS"
+- GPU passthrough: if you're running local models, VM GPU passthrough adds complexity
+- Actual guide: Install Linux (Ubuntu/Debian), install dependencies, install Hermes via one-liner, give it sudo, snapshot immediately after config is working
+
+---
+
+### 🥉 Tier 3: Docker (Stable Only)
+
+**What it is:** Official `nousresearch/hermes-agent` image. s6-overlay supervised. One container can host multiple profiles.
+
+**When Docker works:**
+- Your setup is stable and you're not actively adding tools/dependencies
+- You need clean separation between Hermes and host
+- You're running a production gateway that shouldn't touch the host
+- You know Docker well enough to troubleshoot volume mounts, permission issues, and missing tools
+
+**When Docker fails (community consensus):**
+- "The docker image for hermes is VERY limited. It doesn't have all the tools/skills hermes needs. It doesn't even have a web browser or search!" — u/halarioushandle
+- "I find it tricky to keep the system stable and manage access to the host, not to mention the hassle of managing Hermes updates since I had to rebuild everything from scratch" — u/TransportationLow130
+- "Dealing with the container issues is not worth it" — u/radicalscents
+- "once hermes gets into container, it cannot do any system maintenance work anymore" — u/This_Maintenance_834
+- Cron jobs inside Docker add complexity — Hermes runs cron internally and Docker constrains that
+- Missing tools: you'll need to install skills, browsers, and system deps after container setup
+
+**Official Docker quickstart:**
+```sh
+mkdir -p ~/.hermes
+docker run -it --rm \
+  -v ~/.hermes:/opt/data \
+  nousresearch/hermes-agent setup
+
+# Gateway mode (background):
+docker run -d \
+  --name hermes \
+  --restart unless-stopped \
+  -v ~/.hermes:/opt/data \
+  -p 8642:8642 \
+  nousresearch/hermes-agent gateway run
+
+# With dashboard:
+docker run -d \
+  --name hermes \
+  --restart unless-stopped \
+  -v ~/.hermes:/opt/data \
+  -p 8642:8642 \
+  -p 9119:9119 \
+  -e HERMES_DASHBOARD=1 \
+  nousresearch/hermes-agent gateway run
+```
+
+**Resource minimums (official):**
+| Resource | Minimum | Recommended |
+|----------|---------|-------------|
+| Memory | 1 GB | 2-4 GB (4 GB with browser tools) |
+| CPU | 1 core | 2 cores |
+| Disk | 500 MB | 2+ GB |
+
+**Docker Compose example:**
+```yaml
+services:
+  hermes:
+    image: nousresearch/hermes-agent:latest
+    container_name: hermes
+    restart: unless-stopped
+    command: gateway run
+    ports:
+      - "8642:8642"
+      - "9119:9119"
+    volumes:
+      - ~/.hermes:/opt/data
+    environment:
+      - HERMES_DASHBOARD=1
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+          cpus: "2.0"
+```
+
+**⚠️ Avoid browser-based VPS consoles** (Hetzner Cloud, etc.) for the initial docker run — they corrupt special characters. Connect via SSH instead.
+
+**Multi-profile in one container** (official, s6-supervised):
+```sh
+docker exec hermes hermes profile create work
+docker exec hermes hermes -p work gateway start
+```
+
+**Docker pro-tip:** Mount `/var/run/docker.sock` if you want Hermes to manage other containers from inside its own container. This is an advanced pattern — u/jereminius reports it works for browser tools and container management.
+
+---
+
+### ⚠️ Tier 4: Hybrid / Experimental
+
+**Host-level Hermes + Docker sub-agents** — the OP of "Docker limitations" proposed this and it was validated by multiple commenters as technically feasible:
+- One Hermes installed directly on the host (root access) as "admin"
+- Sub-agents in individual Docker containers for isolated tasks
+- Plumbing via Ansible, Puppet, or SSH keys between them
+- "Running a host-level agent that orchestrates dockerized sub-agents is doable with something like Ansible or Puppet for the plumbing" — u/Automatic-Cover-1831
+
+**Distrobox + Quadlet** (u/Necessary_Two_9669): Containerized with better host integration than plain Docker.
+
+**Terraform + Ansible + Podman (rootless, quadlet)** for VPS deployment (u/_zendar_).
+
+---
+
+## Part 2: VPS Provider Comparison
+
+| Provider | Price/Month | Verdict | Notes |
+|----------|------------|---------|-------|
+| **Hetzner** | €4-8 | 🥇 Community pick | Reliable, SSH-friendly, good price/perf |
+| **Netcup** | $10-13 | 🥈 Solid | Used by multiple community members |
+| **Oracle Cloud** | Free tier | 🥈 Best free option | Generous free tier, block storage, Tailscale-friendly. Setup is "corporate tech" (not user-friendly). Quality can degrade after initial allocation. Limited availability by region. |
+| **AWS EC2** | Varies ($200 free credit) | 🥉 Temporary | Free credits work but burns fast. ~$1.50/day on modest instance. |
+| **Hostinger** | Varies | ⚠️ Avoid | Called "biggest culprit" in affiliate marketing by multiple users. "These people are getting paid big bucks" — u/Creative_Diver3492 |
+| **Hetzner Storage Share** | $4/mo | 🥉 | Good companion storage, not for compute |
+
+**Real community budget (from u/Background-Remote765):** Netcup VPS ($10-13/mo) + Hetzner Storage ($4/mo) + DeepSeek API ($5-10/mo) = **~$30-35/month total** — replacing Spotify, Google ecosystem, and AI subscriptions.
+
+---
+
+## Part 3: Networking & Remote Access
+
+### 🥇 Tailscale (mesh VPN) — Community Pick
+
+"Use Tailscale, runs cleanly" — u/xyesca
+
+- Zero open ports. Hermes dashboard accessible only to devices on your Tailscale network.
+- Works with VPS, home server, and mobile.
+- Free for personal use (up to 100 devices).
+- Combined with Cloudflare Tunnel for public-facing services if needed.
+
+### 🥈 Cloudflare Tunnel
+
+- Access Hermes Dashboard from anywhere without opening ports.
+- **Security note:** Keep "mission control" (third-party admin UIs) on Tailscale only, not on public Cloudflare tunnels — "mission control exposed on a public tunnel is a wider attack surface than you need" — u/Profanonyme1337
+- Combine with Cloudflare Zero Trust for authentication layer.
+
+### 🥉 SSH Tunnels (Manual)
+
+The OP of the SSH tunnel thread found a working pattern:
+1. SSH config forwards local ports to remote VPS
+2. Dashboard accessible at `http://127.0.0.1:9119` locally
+3. Hermes Desktop connects to that forwarded port
+
+**Critical fix they discovered:** Enable the `dashboard_auth/basic` plugin. Without it, the dashboard silently fails to start when running as a systemd background process — and the Desktop app can't authenticate.
+
+### Other options mentioned: NetBird, Pangolin (self-hosted VPN)
+
+---
+
+## Part 4: Security Hardening
+
+### Community-Vetted Practices
+
+**Minimal VPS setup** (from u/orthogonal-ghost on Hetzner):
+1. Create a non-root `hermes` user with sudo (but don't give it the sudo password — Hermes prompts when it needs elevation)
+2. Disable root login and password authentication in SSH config
+3. Restrict firewall to approved IPs only (or Tailscale-only access)
+4. Keep Hermes on its own VPS — don't share with other services
+
+**Dashboard security** (official docs, hardened June 2026 after MCP-config persistence campaign):
+- The dashboard auth gate is now **mandatory** on non-loopback binds
+- Easiest path: `HERMES_DASHBOARD_BASIC_AUTH_USERNAME` + `HERMES_DASHBOARD_BASIC_AUTH_PASSWORD`
+- For public exposure: OAuth via Nous Portal or self-hosted OIDC
+- **Never** expose an unauthenticated dashboard to the internet
+
+**Credential protection:**
+- Use AgentVault (mentioned by u/AnticitizenPrime) to prevent credential leaks
+- Nightly backups to external drive
+- Hermes built-in safeguards prevent leaking env vars/credentials (u/Howard_banister)
+
+**The "full send" approach** (u/p_viljaka):
+"i gave it its own linux VPS and basically 'full send', it has root / sudo — yolo, i told its his own box and take care of it and dont fuck around, and no more box'es if it screws up. It seems happy."
+
+This works because: Hermes on its own VPS with no shared services can't hurt anything beyond itself. Combined with backups, this is lower-risk than it sounds.
+
+---
+
+## Part 5: Local Hardware Alternatives
+
+Skip the VPS entirely. The community overwhelmingly prefers local hardware:
+
+| Hardware | Cost | RAM | Notes |
+|----------|------|-----|-------|
+| Used Dell Optiplex | ~$100 | 32GB DDR4 | Homelab gold. Proxmox-ready. |
+| Raspberry Pi 5 | ~$80 | 8GB + NVMe | "No issues so far" for gateway-only |
+| Used Mac Mini | ~$200-400 | 16GB+ | "No fan, low consumption, works perfect" |
+| Intel N100 Mini PC | ~$150 | 16GB | "Smallest VM possible was enough" |
+| Old laptop (any) | Free-$100 | Varies | Reformat with Linux, install Hermes directly |
+| Orange Pi w/ NPU | ~$100 | Varies | Self-hosted with NPU acceleration |
+| HP ProDesk (salvaged) | Free | Varies | "Found being thrown away on the side of the road" |
+
+**Why local wins:**
+- No monthly cost after hardware purchase
+- No latency between you and your agent
+- Full control — no provider terms of service, no data egress fees
+- "No tailscale, no vps, no costs whatsoever" — u/[deleted] running Qwen 3.6 locally behind router firewall with Discord gateway
+
+**The used Mac Mini pattern** (u/RPendragon_ & Jonathan_Rivera): Ideal always-on Hermes host — silent, low power, runs macOS natively for Apple ecosystem integrations (Reminders, Notes, iMessage, AppleScript, CUA driver).
+
+---
+
+## Part 6: Browser Automation — The #1 VPS Frustration
+
+This deserves its own section because it's the single biggest complaint across all VPS threads.
+
+**The problem:** Headless browsers on VPS datacenter IPs get flagged by WAF/anti-bot systems constantly — Cloudflare, DataDome, Akamai all block datacenter IP ranges.
+
+**Community solutions (tiered):**
+
+1. **Avoid browser automation when possible.** "Agents speak and read text way better than puppeting a browser and screenshotting" — u/Starrwulfe (+25). Use APIs and CLIs instead: Exa for search, Himalaya for email, CLI tools for everything else.
+
+2. **Anti-detection browsers:**
+   - Camofox (`github.com/jo-inc/camofox-browser`) — built for this, free
+   - Camoufox — C-level anti-detection, free, more aggressive fingerprinting
+   - Note: these are different browsers. Camofox ≠ Camoufox.
+
+3. **Residential proxies** — Add a residential proxy layer. Costs money but bypasses datacenter IP blocks.
+
+4. **CAPTCHA services:** unblockingapi.com, Zyte, Scrapingbee — for sites that throw CAPTCHAs.
+
+5. **Browserbase / Browserless free trials** — Cloud browser services with better IP reputation. Free tiers exist.
+
+6. **Firecrawl** — worked for OP where Camoufox failed on real estate sites.
+
+**The real lesson:** If you need heavy browser automation, a VPS is the wrong platform. Run it locally or use API-first alternatives.
+
+---
+
+## Part 7: Log Management
+
+**You will run out of disk.** Multiple users reported this.
+
+- Session logs live in `~/.hermes/sessions/`
+- SQLite state database at `~/.hermes/state.db`
+- Gateway logs at `~/.hermes/logs/gateways/<profile>/current`
+
+**For Docker:** Gateway logs are tee'd to both `docker logs` AND rotated files on the bind-mounted volume (10 archives × 1 MB each per profile). The boot reconciler writes to `~/.hermes/logs/container-boot.log`.
+
+**Action items:**
+- Set up logrotate for `~/.hermes/sessions/` and `~/.hermes/logs/`
+- Monitor disk usage: "session logs and the SQLite state.db will fill a 20GB disk faster than you'd expect on active use" — u/Profanonyme1337
+- Docker: `docker logs` only covers current container lifetime; rotated files on volume persist
+
+---
+
+## Part 8: FAQ
+
+**Q: Should I use Docker for Hermes?**
+A: Not if you're still exploring or adding tools. Docker is good for stable production setups where the toolset is locked in. For active development, use bare metal or a VM with snapshots.
+
+**Q: What's the cheapest way to run Hermes 24/7?**
+A: A used Dell Optiplex (~$100) or Raspberry Pi 5 (~$80). One-time cost, zero monthly fees. If you need cloud, Oracle free tier or Hetzner at €4/mo.
+
+**Q: How do I access my VPS Hermes securely?**
+A: Tailscale. No open ports. Access dashboard, API, and SSH from anywhere on your mesh network. Free for personal use.
+
+**Q: Why does my browser automation fail on VPS?**
+A: Datacenter IPs are flagged by anti-bot systems. Use Camofox browser, residential proxies, or (better) API/CLI alternatives.
+
+**Q: Can Hermes run multiple profiles in one Docker container?**
+A: Yes — the official image uses s6-overlay to supervise per-profile gateways. `docker exec hermes hermes profile create <name>` is all you need. No second container.
+
+**Q: Should I expose my Hermes dashboard to the internet?**
+A: If you must, enable authentication. The dashboard **refuses to start** on a public bind without an auth provider as of June 2026. Use basic auth (`HERMES_DASHBOARD_BASIC_AUTH_USERNAME` + `_PASSWORD`) or OAuth. Better: keep it on Tailscale.
+
+**Q: How much does running Hermes on a VPS actually cost?**
+A: Community reports: $30-35/month all-in (VPS + storage + API tokens) for an active setup. Local hardware breaks even in 3-6 months.
+
+**Q: What's the "Hermes Desktop to VPS" connection path?**
+A: SSH tunnel to forward port 9119 → enable `dashboard_auth/basic` plugin → point Hermes Desktop to `http://127.0.0.1:9119`. Without the auth plugin, the dashboard fails silently.
+
+**Q: Can I run Hermes on a Raspberry Pi?**
+A: Yes — multiple users confirm Pi 5 (8GB) + NVMe works for gateway mode. Not for running local LLMs, but fine as a 24/7 gateway to cloud APIs.
+
+**Q: What about Proxmox?**
+A: Heavily endorsed. Run Hermes in an LXC or VM, snapshot the working config, roll back instantly if something breaks. "Snapshot that MF" — u/100PercentJake
+
+---
+
+## Part 9: Knowledge Table — Every Tool & Service Mentioned
+
+| Name | Type | Cost | Best For | Watch For |
+|------|------|------|----------|-----------|
+| **Hetzner** | VPS | €4-8/mo | Production Hermes hosting | Browser console corrupts paste |
+| **Oracle Cloud** | VPS | Free tier | Budget 24/7 hosting | Limited availability, degrades |
+| **Netcup** | VPS | $10-13/mo | Budget VPS | Less known, fewer guides |
+| **AWS EC2** | Cloud | $200 free credit | Trial/temporary | Credits burn ~$1.50/day |
+| **Tailscale** | Mesh VPN | Free (personal) | Secure remote access | Requires client on each device |
+| **Cloudflare Tunnel** | Tunnel | Free | Public access without ports | Don't expose admin UIs on it |
+| **Proxmox** | Hypervisor | Free | VM snapshots, homelab | RAM overhead for host OS |
+| **Camofox** | Browser | Free | Anti-detection browsing | Different from Camoufox |
+| **Camoufox** | Browser | Free | C-level anti-detection | Heavier fingerprinting |
+| **Firecrawl** | Web scraping | Paid | Sites that block headless | Not free at scale |
+| **Browserbase** | Cloud browser | Free trial | CAPTCHA-heavy sites | Trial limited |
+| **Exa** | Search API | Paid | Search without browser | API cost at scale |
+| **Himalaya** | Email CLI | Free (built-in) | IMAP/SMTP in Hermes | Proton needs paid tier for IMAP |
+| **Composio** | API integration | ? | Connecting services | Newer tool |
+| **Dokploy** | Docker manager | Free | Managing Docker Hermes | Adds another layer |
+| **AgentVault** | Credential protection | ? | Preventing API key leaks | Setup overhead |
+| **Zyte / Scrapingbee** | CAPTCHA solving | Paid | Unblocking headless browsers | Ongoing cost |
+| **unblockingapi.com** | CAPTCHA solving | Paid | Alternative to Zyte | Less established |
+| **Meragpt.com** | Managed Hermes | Paid | Zero-setup Hermes hosting | Vendor lock-in |
+| **Distrobox + Quadlet** | Container | Free | Docker-like with host access | Podman knowledge needed |
+| **TinyAgentOS** | Bare-metal agent OS | Free | Streamlined Hermes on metal | github.com/jaylfc/tinyagentos |
+| **Fox-in-the-Box** | Docker Hermes | Free | Hermes-specific Docker build | github.com/fox-in-the-box-ai |
+
+---
+
+## Part 10: The Bottom Line
+
+The community has spoken clearly: **Docker is the wrong default for Hermes.** It's a production optimization, not a starting point. Start on bare metal or a VM, give Hermes the freedom it needs, snapshot often, and only containerize once your toolset is stable and you know exactly what you're doing.
+
+If you're paying for a VPS and burning API tokens while fighting browser automation — you're doing it on hard mode. A $100 used PC running Tailscale will get you further, faster, with less frustration.
+
+---
+
+*This megathread synthesized from 9+ r/hermesagent threads (200+ comments), official Nous Research Docker documentation, the Hermes Dockerfile source, and multiple external deployment guides. Corrections and additions welcome in the comments.*
+
+---
+
+## Comment-Sourced Updates
+
+- **Canonical VPS source:** this June 21 guide supersedes the earlier June 3 and April deployment summaries. Unique older material should be folded here only after verification.
+
+- **Docker sequencing:** commenters correctly distinguish “good production/stability boundary” from “easiest place to experiment.” Start with the simplest topology that meets the isolation requirement.
+
+- **Community deployment projects:** taOS and external setup curricula were suggested; they remain dated external leads pending maintenance and security review.
+
+## Maintaining this guide
+
+Open an issue or pull request with the official source, date checked, Hermes/backend version, and enough reproduction detail to evaluate the change. No referral links, affiliate links, or unsupported promotional claims.

--- a/references/reddit-comment-notes-agent-trust-boundary-2026-07.md
+++ b/references/reddit-comment-notes-agent-trust-boundary-2026-07.md
@@ -1,0 +1,64 @@
+# Reddit Comment Notes — Agent Trust Boundary Megathread
+
+> Source thread: https://www.reddit.com/r/hermesagent/comments/1usz3d3/agent_trust_boundary_megathread_connect_the_tools/
+> Source extraction: repository migration dataset snapshot (local at runtime)
+> Reviewed: July 16, 2026
+
+This file records community comments as provenance for canonical edits.
+
+- Excluded: praise, jokes, and non-actionable repetition.
+- Included: durable additions/corrections and operational patterns.
+
+---
+
+## Inclusion ledger
+
+| Date (UTC) | Author | Type | Concise claim | Decision | Why included / excluded |
+| --- | --- | --- | --- | --- | --- |
+| 2026-07-11 | /u/Dry_Relationship_388 | Addition | User reports a practical split: use Hermes for limited tasks (queries/stats, notes, coding, GitLab push) and keep other operations manual. | Included | Adds a concrete role-segmentation pattern that aligns with zone-based boundaries. Added to use-case catalog examples. |
+| 2026-07-11 | /u/WatercressBudget9418 | Correction | Good agents can report completion without actually completing work; irreversible actions should stay human-gated. | Included | Directly strengthens human-gate policy beyond “agent is malicious” framing. Added to comment-sourced updates and operator rules. |
+| 2026-07-11 | /u/Jonathan_Rivera | Addition | Local-first operation on macOS with cloud redundancy is an effective preference; workflow should stay step-by-step and observable. | Included (as preference) | Useful operational pattern, but marked as preference, not universal requirement. |
+| 2026-07-11 | /u/rittatewa | Addition + Needs-verification | Suggests per-runtime, per-agent credential binding via NyxID (`agent key` + shared provider credential in gateway proxy), avoiding shared-key blast radius. | Included as archived pattern | Useful security architecture idea, but this is external implementation detail and currently not validated in Hermes official docs. Kept in the archive/unverified section for explicit follow-up. |
+
+---
+
+## Archived items (needs verification before canonical use)
+
+| Date (UTC) | Author | Category | Claim | Why archived |
+| --- | --- | --- | --- | --- |
+| 2026-07-11 | /u/rittatewa | Security / external implementation | NyxID architecture for provider credential brokering (`execute_tool()` + `proxy_service.rs`), including a concrete code repo path. | Requires independent validation of implementation quality, compatibility, and maintenance posture before recommending as canonical policy. |
+| 2026-07-11 | /u/Jonathan_Rivera | Subjective / workflow preference | “Local on Mac + cloud redundancy” as preferred operating style. | Not a universal canonical rule; kept as operator preference with scoped inclusion in the guide. |
+
+---
+
+## Excluded / noise
+
+No pure praise, joke-only, or non-operational noise comments were included in this dataset.
+
+### Exclusion rationale (quick)
+
+- No comments were promotional in a way that materially affects trust-boundary policy.
+- No unverifiable benchmark or pricing claims were present in the captured thread.
+- No single-user-only anecdote was promoted as baseline fact; all retained claims were normalized into operational guidance.
+
+---
+
+## Traceability and canonical mapping
+
+| Canonical section | Source comment | Mapping |
+| --- | --- | --- |
+| `6) Comment-sourced updates` (main guide) | `/owwfs13` | Role segmentation examples |
+| `6) Comment-sourced updates` (main guide) | `/owtn94o` | Explicit irreversible-action human gate |
+| `6) Comment-sourced updates` (main guide) | `/owtr7ba` | Local-first + cloud fallback as preference note |
+| `6) Comment-sourced updates` (main guide) | `/owyf2ej` | Needs-verification security architecture note |
+| `7) Unresolved community claims` (main guide) | `/owyf2ej` | Archived NyxID pattern |
+| `7) Unresolved community claims` (main guide) | `/owtr7ba` | Subjective preference classification |
+
+---
+
+## Link index (external references)
+
+- `/owwfs13`: https://www.reddit.com/r/hermesagent/comments/1usz3d3/agent_trust_boundary_megathread_connect_the_tools/owwfs13/
+- `/owtn94o`: https://www.reddit.com/r/hermesagent/comments/1usz3d3/agent_trust_boundary_megathread_connect_the_tools/owtn94o/
+- `/owtr7ba`: https://www.reddit.com/r/hermesagent/comments/1usz3d3/agent_trust_boundary_megathread_connect_the_tools/owtr7ba/
+- `/owyf2ej`: https://www.reddit.com/r/hermesagent/comments/1usz3d3/agent_trust_boundary_megathread_connect_the_tools/owyf2ej/

--- a/references/reddit-comment-notes-cost-token-optimization-2026-06.md
+++ b/references/reddit-comment-notes-cost-token-optimization-2026-06.md
@@ -1,0 +1,193 @@
+# Reddit Comment Notes — Cost & Token Optimization Megathread — Hermes Agent (June 2026)
+
+Original thread: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/
+
+Captured for provenance during the July 16, 2026 migration. Classification is editorial triage, not independent verification. Promotional, reputational, pricing, benchmark, version, and availability claims require primary-source checks before entering the canonical guide.
+
+Praise, jokes, GIFs, removed/deleted bodies, bot reminders, and other non-substantive comments are intentionally omitted.
+
+### u/roverowl — Addition or operator report
+
+- Score at capture: 6
+- Comment: Mimo2.5 family is better than Deepseek
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/ot99wrs/
+### u/zer0evolution — Needs verification
+
+- Score at capture: 2
+- Comment: price? have many option if more expensive than deepseek .
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/ot9m0ol/
+### u/roverowl — Addition or operator report
+
+- Score at capture: 2
+- Comment: go straight to the source: https://platform.xiaomimimo.com/. I got 11bilion tokens plan for ~$15/month . Self plug: using my code AEX9XY for $2 API credits + 10% off your plan.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/ot9s7zo/
+### u/zer0evolution — Addition or operator report
+
+- Score at capture: 1
+- Comment: https://preview.redd.it/vhklkyvf419h1.png?width=830&format=png&auto=webp&s=3003aa601e5e8af98eccfd3c7d78b39e18957f4c i think my usage is under 4.1 B, so thanks for the suggestion, after payday i consider to try this
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/otbeyb4/
+### u/purple621 — Addition or operator report
+
+- Score at capture: 2
+- Comment: Cache read only $0.002 I second this
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/otfmmnr/
+### u/djseto — Addition or operator report
+
+- Score at capture: 3
+- Comment: Where is qwen3.5 35B a4b mtp in all of this? I find its performance pretty snappy on a m4 max with 64B. 27B does work but the dog slow. Would love to know the delta between the two as local LLMs
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/ot8pwuy/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 2
+- Comment: You have your own mac megathread u/djseto , don't be greedy lol [https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac\_mlx\_megathread\_hermes\_agent\_on\_apple\_silicon/](https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/)
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/ot8ybz4/
+### u/djseto — Addition or operator report
+
+- Score at capture: 3
+- Comment: Haha. I totally missed that thread. Going over there now!
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/ot908ip/
+### u/SirJohnSmythe — Addition or operator report
+
+- Score at capture: 1
+- Comment: The cost estimate for DeepSeek seems high IMHO
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/ot81iwu/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 1
+- Comment: It depends on use of the person or people that made the comment that was scraped. I had deepseek pro for primary and flash for sub-agents and spent about $2.00 for the research on 4 megathreads. Today I used deepseek pro and it did not delegate and cost $6.50.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/ot82vyy/
+### u/avadreams — Needs verification
+
+- Score at capture: 1
+- Comment: Is deepseek still "75% off" promotion or did they make that the permanent API price? Also I'm using Mimo because it was same price but better results. Noticable degredation of Deepseek intelligence after the first two weeks of v4
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/ot85eky/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 1
+- Comment: Permanent now. https://preview.redd.it/pt7uzmtx6x8h1.png?width=852&format=png&auto=webp&s=329652d9c0588ddb134629ab174a8aa83dc93145
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/ot85rx7/
+### u/bullyliit — Addition or operator report
+
+- Score at capture: 1
+- Comment: Did you use the sub or direct API? Planning to swap Deepseek Pro with Mimo Pro
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/otb3pa8/
+### u/avadreams — Addition or operator report
+
+- Score at capture: 2
+- Comment: Api
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/otbaiya/
+### u/SirJohnSmythe — Addition or operator report
+
+- Score at capture: 1
+- Comment: I meant more the $3-10 monthly estimate for Flash.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/ot8eu7e/
+### u/ricorick — Addition or operator report
+
+- Score at capture: 1
+- Comment: Have you tried an ollama local or llama cpp for compression I’m usually small local model to do compression at 90k and it keeps my cost down also lowered keep last 20 to 10 or 8 and it works
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/ot8bk3g/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 2
+- Comment: I am using qwen3.5-9b-uncensored-hauhaucs-aggressive for compression on LM studio. If I'm using a cloud model for primary i move Aux to Deepseek flash.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/ot8ebm3/
+### u/Salt_Bed79 — Addition or operator report
+
+- Score at capture: 1
+- Comment: I tried to use ollama with models like gpt oss 120 and qwen local models but the response time was more , so I left it
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/ot9z1ms/
+### u/throwRAa100 — Addition or operator report
+
+- Score at capture: 1
+- Comment: for running local models why were 3090, 3060, m1 max 64gb, and 2x 5090 chosen? Just wondering what the optimal model would be if someone was running a 4090 or 5090?
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/ot8heum/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 2
+- Comment: The initial prompt was suggest 3 megathreads based off community questions over the last 45 days. These edge cases were the most vocal across that timeline.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/ot8jp5j/
+### u/alphaQ314 — Addition or operator report
+
+- Score at capture: 1
+- Comment: Deepseek is hot trash imo. I don't get all the fascination with it. I set the model to the pro, and asked it to change my hermes model to opus. It just changed one line from deepseek to opus, without the underlying changes to everything else. Lost all trust in it instantly.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/ot9q1zk/
+### u/giveen — Addition or operator report
+
+- Score at capture: 1
+- Comment: How did you ask? Did you provide reference? "Heh change me to Opus"...or did you say "I would like to change my default model to Opus, here is my API key and here is the [https://router.for.opus.com](https://router.for.opus.com) "
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/otfm8pc/
+### u/alphaQ314 — Addition or operator report
+
+- Score at capture: 1
+- Comment: I asked opus to move me to "deepseek pro". It managed it just fine. Then i asked deepseek to "change the model back to opus".
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/othbfgb/
+### u/tortel_di_patate — Addition or operator report
+
+- Score at capture: 1
+- Comment: &gt;🥇 **Daily driver:** DeepSeek V4 Flash, Minimax 2.7, Qwen 3.6-27B (local) Is Qwen 3.6-27B of a comparable "quality" or "intelligence" to a hosted model like DS v4 Flash?
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/otd1bxg/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 1
+- Comment: Qwen 3.6-27B is the best that many can hope to run locally and can be competitive and is more consistant whereas deepseek flash is probably more capable as a 13 billion parameter MOE model with 284 billion total parameters.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/otd8lll/
+### u/tortel_di_patate — Needs verification
+
+- Score at capture: 1
+- Comment: What do you think of Mistral? It's an european company, and so it should have less privacy concerns than Claude (US) or Deepseek/Kimi(China). Pricing is not that higher compared to DS https://preview.redd.it/mejw8if3i29h1.jpeg?width=751&format=pjpg&auto=webp&s=2969d5a3ca2e3a1efb31e213148ae5f09ad8cec9
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/otd4gde/
+### u/xmsxms — Addition or operator report
+
+- Score at capture: 1
+- Comment: No mention of owl alpha on open router which is currently free?
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/otdh9ic/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 1
+- Comment: It’s not being discussed enough compared to the others to het picked up in this report.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/otdm7jb/
+### u/xmsxms — Addition or operator report
+
+- Score at capture: 1
+- Comment: Fair enough, although it's free with a 1M context, I would have thought it would be more widely used.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/oteoxwc/
+### u/Ok_Entertainment1340 — Addition or operator report
+
+- Score at capture: 1
+- Comment: What about minimax? M3 does pretty well for $17/mo
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/otmbnn0/
+### u/purple621 — Addition or operator report
+
+- Score at capture: 1
+- Comment: Toolset config should be done via cli and not dashboard as if v 2026.06.19 https://www.reddit.com/r/hermesagent/s/41uXSGKnSm
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/oucasc5/
+### u/Jorvex609 — Addition or operator report
+
+- Score at capture: 1
+- Comment: So, can someone create a skill that I can simply feed to the agent, allowing it to configure itself to consume fewer tokens? I'd also like to use a local Qwen model for automated tasks and DeepSeek for when I interact with the agent directly.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/oud5091/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 1
+- Comment: There isn't one magic "configure me to be cheap" skill (yet), but the biggest wins are all configuration, not prompts. In rough order of impact: \- Disable unused tools. hermes tools → toggle off anything you don't use. Tool schemas are the #1 token hog at startup (often 11–13k tokens). Trimming from 32 tools down to 8–10 can cut initial payload by 30–40%. \- Disable unused skills. Add them to skills.disabled in config.yaml. If you've installed 100+ skills from the hub, the index alone adds thousands. \- Tune compression. hermes config set compression.enabled true → tune threshold (0.85) and target\_ratio (0.70). Docs: [https://hermes-agent.nousresearch.com/docs/developer-guide/context-compression-and-caching](https://hermes-agent.nousresearch.com/docs/developer-guide/context-compression-and-caching) \- Token-router plugin - predicts which tools you'll need per-turn, only loads those schemas. Narrows 32→\~8 tools on most turns. \- Small aux model for background tasks - compression, title gen, session search can run on a cheap local model while main is DeepSeek. Most token waste happens at session START. Tool schemas + memory + skills loaded upfront. Attack those first.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/oud9kil/
+### u/haltingpoint — Addition or operator report
+
+- Score at capture: 0
+- Comment: If you go direct with Deepseek be aware your data is being sent to China.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/ot8v47x/
+### u/Worried_Corner_8541 — Addition or operator report
+
+- Score at capture: 4
+- Comment: instead send it to claude and gpt in America, right? unless you run locally someone else sees your data anyway.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/ota8lbm/
+### u/Momsbestboy — Needs verification
+
+- Score at capture: 1
+- Comment: Which is the reason I find the following aspect above, well, ..... &gt; When Claude is worth it: Complex multi-step coding, security-sensitive work,
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/otakteu/
+### u/Alan1900 — Addition or operator report
+
+- Score at capture: 1
+- Comment: That doesn't make any practical difference re. privacy
+- Source: https://www.reddit.com/r/hermesagent/comments/1ud03si/cost_token_optimization_megathread_hermes_agent/ot9unhd/

--- a/references/reddit-comment-notes-free-models-apis-2026-06.md
+++ b/references/reddit-comment-notes-free-models-apis-2026-06.md
@@ -8,7 +8,7 @@ This file archives comments captured from the RSS feed so future maintainers can
 This archive excludes Jonathan's own follow-up comments so the reference file focuses on community feedback and suggestions.
 ## 1. /u/akgo
 
-- Link: 
+- Link:
 
 
 Who is actually able to use these free models.
@@ -19,7 +19,7 @@ Why would anyone give you such free quota.?
 
 ## 3. /u/akgo
 
-- Link: 
+- Link:
 
 
 Makes sense. Deploy it for small tasks is a good idea but again it takes a lot of time to check everything in blah blah blah. How do you deal with that do you have a system in place?
@@ -32,21 +32,21 @@ But not to adjust to it and how it behaves I have to think again and understand 
 
 ## 5. /u/tomByrer
 
-- Link: 
+- Link:
 
 
 This should be in a GitHub repo or something.
 
 ## 6. /u/xhp-eth
 
-- Link: 
+- Link:
 
 
 I agree with this one. So everyone can be a collaborator to update the information.
 
 ## 8. /u/tomByrer
 
-- Link: 
+- Link:
 
 
 Mostly because other people can help edit, & you can approve said edits or refuse.
@@ -55,7 +55,7 @@ Mostly because other people can help edit, & you can approve said edits or refus
 
 ## 10. /u/fleperson
 
-- Link: 
+- Link:
 
 
 - Install Obsidian (visual editing Markdown files)
@@ -70,7 +70,7 @@ GG
 
 ## 11. /u/tomByrer
 
-- Link: 
+- Link:
 
 
 Any git client (including the CLI) can sync between Obsidian & Github.
@@ -81,14 +81,14 @@ Github.com
 
 ## 12. /u/fleperson
 
-- Link: 
+- Link:
 
 
 I know, I just suggested a super easy path for OP as he stated he is not much famliar with GH. Doing with plugins inside Obsidian might be easier to start fiddling with it.
 
 ## 13. /u/tomByrer
 
-- Link: 
+- Link:
 
 
 I use Obsidian, but using with plugins it is kinda advanced. I still don't know how plugins do NOT get cloned from my desktop to mobile versions.
@@ -97,35 +97,35 @@ BTW, this is a HERMES AGENT sub; folks should be automating everything, not usin
 
 ## 14. /u/chanc2
 
-- Link: 
+- Link:
 
 
 I’ve used OpenRouter:free in the past with OpenClaw. Found it to be unreliable and slow. Moved to DeepSeek v4 using Deepseek’s API with Hermes and it’s been working great.
 
 ## 15. /u/chesco11
 
-- Link: 
+- Link:
 
 
 oh I wonder if there's a difference with using Deepseek via openrouter api..
 
 ## 16. /u/chanc2
 
-- Link: 
+- Link:
 
 
 I went direct to DS API and I’m really happy with the performance. No delay in the responses. I didn’t try DA via OpenRouter. I wanted to tap into the super low token pricing that DS is offering.
 
 ## 17. /u/chesco11
 
-- Link: 
+- Link:
 
 
 thank you! that makes sense!
 
 ## 18. /u/moreoronce
 
-- Link: 
+- Link:
 
 
 "SiliconFlow deserves a spot on this list — free API access to Qwen3 models including the VL-32B variant with native vision input. I've been running it as my image analysis provider in Hermes for a while and tool-use works well out of the box.
@@ -142,28 +142,28 @@ Also — if your agent tasks touch any Chinese/CJK content, Qwen3 on SiliconFlow
 
 ## 19. /u/Kamalcr77
 
-- Link: 
+- Link:
 
 
 Wait, is deepseek free on open router? Are you sure?
 
 ## 21. /u/Kamalcr77
 
-- Link: 
+- Link:
 
 
 It's not available anymore... Please verify. Check openrouter/free. It's not listed there.
 
 ## 23. /u/impoze
 
-- Link: 
+- Link:
 
 
 Also tried but says not available free anymore
 
 ## 25. /u/impoze
 
-- Link: 
+- Link:
 
 
 I think that ends soon though, almost at 30 days.
@@ -172,28 +172,28 @@ I've been using openrouter/owl -alpha and nvidia/nemotron-3
 
 ## 27. /u/Draunzr
 
-- Link: 
+- Link:
 
 
 What happens after that ? They'll remove the free tier completely or give us a even dumber model ?
 
 ## 29. /u/TourSignificant7065
 
-- Link: 
+- Link:
 
 
 Owl alpha is retiring soon so be wary about that
 
 ## 31. /u/spacenglish
 
-- Link: 
+- Link:
 
 
 Graduated from free to paid.
 
 ## 32. /u/carbolymer
 
-- Link: 
+- Link:
 
 
 Q: What free APIs exist outside of OpenRouter? A: Google AI Studio,
@@ -206,35 +206,35 @@ how do you add an api key for free tier?
 
 ## 33. /u/brandeded
 
-- Link: 
+- Link:
 
 
 I use groq, but leverage litellm locally hosted for routing. Still working this out.
 
 ## 34. /u/knowoneknows
 
-- Link: 
+- Link:
 
 
 How do yall handle the data retention issue with free models? Are you okay allowing the collection of any and all data you're working with?
 
 ## 35. /u/jkoehler11
 
-- Link: 
+- Link:
 
 
 I've been using deepseek-v4-pro under the free opencode.ai go tier and I have yet to hit any of the limits. I have openrouter/free and local ollama for backup but haven't needed it.
 
 ## 36. /u/pumpkin_biscuits1
 
-- Link: 
+- Link:
 
 
 Sadly Owl-Alpha disappeared overnight. It is going to be a paid model soon.
 
 ## 38. /u/Draunzr
 
-- Link: 
+- Link:
 
 
 What about stepfun step 3.7 flash. Been using, it does the tasks mostly but gives gibberish replies sometimes like I haven't asked it anything related to docker at all and it'll give a response explaining docker on its own. Does someone know how stepfun compared to like owl alpha for gemma 4

--- a/references/reddit-comment-notes-hermes-agent-use-cases-2026-07.md
+++ b/references/reddit-comment-notes-hermes-agent-use-cases-2026-07.md
@@ -1,0 +1,188 @@
+# Reddit Comment Notes — MEGATHREAD: Hermes Agent Use Cases — What the Community is Building (May 2026)
+
+Original thread: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/
+
+Captured for provenance during the July 16, 2026 migration. Classification is editorial triage, not independent verification. Promotional, reputational, pricing, benchmark, version, and availability claims require primary-source checks before entering the canonical guide.
+
+Praise, jokes, GIFs, removed/deleted bodies, bot reminders, and other non-substantive comments are intentionally omitted.
+
+## Link-health notes from migration review
+
+The following URLs appeared only inside archived Reddit comments and returned HTTP 404 when checked July 16, 2026. They are retained in the excerpts for provenance, not presented as working recommendations:
+
+- `https://github.com/svenmedina07-ship-it/skills/tree/main/acca-tracker`
+- `https://github.com/Yarmoluk/cognify-skills`
+- `https://github.com/tiann/execplan`
+
+HTTP 403 responses from Reddit/Product Hunt and similar anti-bot surfaces were treated as access restrictions, not proof that a link is dead.
+
+### u/Darthmichael12 — Addition or operator report
+
+- Score at capture: 22
+- Comment: I’m just going to copy and paste this into Hermes and see if he can do anything. 😂
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/okhd8aa/
+### u/ItalianAmericanDad — Addition or operator report
+
+- Score at capture: 7
+- Comment: Prompt will be : Ok, do something with this
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/okil680/
+### u/Darthmichael12 — Addition or operator report
+
+- Score at capture: 4
+- Comment: Exactly! Like review this and see what you can implement! And it will just work until it does something! 😂
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/okiob72/
+### u/ItalianAmericanDad — Addition or operator report
+
+- Score at capture: 3
+- Comment: Based on my lifestyle😆
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/okioo70/
+### u/trueimage — Addition or operator report
+
+- Score at capture: 1
+- Comment: Big Brain over here
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/okii15d/
+### u/Code_Doctor_83 — Addition or operator report
+
+- Score at capture: 1
+- Comment: LOL exactly my thoughts!
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/okocs4q/
+### u/FanClubof5 — Addition or operator report
+
+- Score at capture: 9
+- Comment: So much of this make zero sense. Like how did you reduce your AI token usage by changing where the code runs? &gt;90% token spend cut. Runs on a cheap Android via Termux
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/okii7k6/
+### u/mb99 — Addition or operator report
+
+- Score at capture: 8
+- Comment: I like the idea of this but imo this list is basically unusable as it’s such a wall of text / there’s so many things listed
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/okjf88g/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 0
+- Comment: It’s a lot easier to read on desktop if your on mobile.
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/okjr4ns/
+### u/radix- — Addition or operator report
+
+- Score at capture: 1
+- Comment: How do I find the ones without links?
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/oksxk85/
+### u/midwestcsstudent — Addition or operator report
+
+- Score at capture: 1
+- Comment: why not a sheet lol
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/okx67gp/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 2
+- Comment: Part of the journey of using Hermes myman. I have Gemini, Claude, and GPT subscriptions that would have aced it but really i'm committing to using Hermes and mistakes are part of the process that y'all get to see.
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/okx9l48/
+### u/midwestcsstudent — Addition or operator report
+
+- Score at capture: 1
+- Comment: what
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/olb49vq/
+### u/Jonathan_Rivera — Needs verification
+
+- Score at capture: 8
+- Comment: Part 3 ## Round 11 — awesome-hermes-agent Directory (71 new projects) Community-curated projects from the awesome-hermes-agent repository that expand Hermes capabilities across all domains. | Use Case | Source | |----------|--------| | **42-evey** — Goal management, inter-agent bridge, model selection, cost control | [42-evey on GitHub](https://github.com/42-evey) | | **hermes-skill-factory** — Meta-skill that auto-generates reusable skills from workflows | [Romanescu11 on GitHub](https://github.com/Romanescu11/hermes-skill-factory) | | **litprog-skill** — Literate programming skill for Claude Code, OpenCode, Hermes | [tlehman on GitHub](https://github.com/tlehman/litprog-skill) | | **acpa-tracker** — Multi-sport accumulator betting slips tracker | [svenmedina07-ship-it on GitHub](https://github.com/svenmedina07-ship-it/skills/tree/main/acca-tracker) | | **hermes-spotify-skill** — Spotify playback control for headless Linux/Raspberry Pi | [Alexeyisme on GitHub](https://github.com/Alexeyisme/hermes-spotify-skill) | | **wondelai/skills** — Cross-platform agent skills | [wondelai on GitHub](https://github.com/wondelai/skills) | | **Anthropic-Cybersecurity-Skills** — Cybersecurity skills for Anthropic models | [mukul975 on GitHub](https://github.com/mukul975/Anthropic-Cybersecurity-Skills) | | **chainlink-agent-skills** — Chainlink integration for AI agents | [smartcontractkit on GitHub](https://github.com/smartcontractkit/chainlink-agent-skills) | | **black-forest-labs/skills** — Skills by Black Forest Labs | [black-forest-labs on GitHub](https://github.com/black-forest-labs/skills) | | **pydantic-ai-skills** — Pydantic AI integration skills | [DougTrajano on GitHub](https://github.com/DougTrajano/pydantic-ai-skills) | | **cognify-skills** — Business operations skills by Yarmoluk | [Yarmoluk on GitHub](https://github.com/Yarmoluk/cognify-skills) | | **execplan-skill** — Execute complex, long-running plans | [tiann on GitHub](https://github.com/tiann/execplan … [excerpt intentionally limited to avoid republishing a large script or identity-specific configuration; use the source link for the full public comment]
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/okhaycz/
+### u/bondybond13 — Addition or operator report
+
+- Score at capture: 6
+- Comment: i wish someone could do one of these curated lists, but rather started with what outcome they achieved (that improved their lives somehow vs. stone age) e.g. daughter rated me 2 pts higher on NPS - because - hermes deliveres her a new customized nighttime story every night - by image generating a storybook on gpt5.4 as a cron job 8pm daily
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/oki3cqe/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 3
+- Comment: It might be better to point your Hermes at this thread and ask it which ones may work best for your use. When aggregating this much data from different locations there’s just too much info to squeeze in a post. Then you get into excel pivot table territory.
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/okkurf9/
+### u/Jonathan_Rivera — Needs verification
+
+- Score at capture: 2
+- Comment: Part 2:..... Part 3 in another sticky post. ## Trading & Markets (13 use cases) Polymarket, crosschain trading, portfolio monitoring, and financial automation. | Use Case | Source | |----------|--------| | Polymarket trading, 4 layers in parallel | X | | $100 to $216 in 48h with a self-learning weather bot | X | | 24/7 crosschain trading agent on Hetzner | Blog | | **Using Hermes to monitor investment portfolio with Telegram integration** | [u/Ok_Version_3193 on Reddit](https://reddit.com/r/hermesagent/comments/1t5drpl/using_hermes_to_monitor_investment_portfolio/) | | **Prediction market integration for Hermes (5 stars)** | [0xharryriddle on GitHub](https://github.com/0xharryriddle/hermes-pmxt) | | **Pyth Network MCP — real-time decentralized oracle price feeds (4 stars)** | [itsOmSarraf on GitHub](https://github.com/itsOmSarraf/pyth-network-mcp) | | **hermes-blockchain-oracle — Solana blockchain intelligence MCP server, query wallets, track whales (4 stars)** | [gizdusum on GitHub](https://github.com/gizdusum/hermes-blockchain-oracle) | | **mercury — blockchain cash flow analyzer, multi-chain analysis, fraud detection, trading strategy (12 stars)** | [hxsteric on GitHub](https://github.com/hxsteric/mercury) | | **clawmes — crypto plugin: wallets, DEX trading, lending, staking, governance, on-chain automation (11 stars)** | [clawnchdev on GitHub](https://github.com/clawnchdev/clawmes) | | **launchpad-skill — Rust CLI for AI agent-driven Solana corporate token management, Company-as-a-Protocol (1 star)** | [waifuai on GitHub](https://github.com/waifuai/launchpad-skill) | --- ## Privacy & Self-Hosted (9 use cases) Edge GPU deployments, Tailscale security, local-first setups, and audit-grade privacy. | Use Case | Source | |----------|--------| | Edge GPU deployments with Tailscale security | X | | Local-first setup: 100% data sovereignty | Blog | | Self-hosted on a Pi 4 — zero cloud dependency | Blog | | **Portable Hermes Agent (102 stars)** — deskt … [excerpt intentionally limited to avoid republishing a large script or identity-specific configuration; use the source link for the full public comment]
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/okhaaji/
+### u/ExtremeKangaroo5437 — Addition or operator report
+
+- Score at capture: 2
+- Comment: MODS: if you think sharing my profile etc are not good for this channle, just ask me and I'll remove.. I am sharing as I feel it's real good use case. I am not so hardcore social media user, but I have created various hermes profiles that has their own identities, assets, posts and journey management and now one profile represent my instagram account (gvs) [https://www.instagram.com/gowravvishwakarma/](https://www.instagram.com/gowravvishwakarma/) and I have created wan2GP skills with flux an LTX2.3 models so now i just say to create next post from telegram and a new asset is genearted or used old one, an anchor image is generated for starting frame ( sometimes intermediate frames and end frame also) and video is genearted compressed and sent to me ... [https://github.com/gowrav-vishwakarma/hermes-shared-skills](https://github.com/gowrav-vishwakarma/hermes-shared-skills) the skills has all the tools also that does the heavy lifting and almost accurate everytime... my assets have character\_girl character\_geek\_boy and characher ( me :D ) these are shared skill for each profile and .env in each profile contains following details # --------------------------------------------------------------------------- # Profile paths # --------------------------------------------------------------------------- PROFILE_ROOT=~/.hermes/profiles/gvs PROFILE_HOME=~/.hermes/profiles/gvs/home PROFILE_SKILLS=~/.hermes/shared-skills POSTS_DIR=~/.hermes/profiles/gvs/home/posts MEMORY_FILE=~/.hermes/profiles/gvs/memories/MEMORY.md JOURNEY_FILE=~/.hermes/profiles/gvs/home/journey.jsonl # --------------------------------------------------------------------------- # WanGP (image + video generation via wgp.py) # --------------------------------------------------------------------------- WAN_APP_DIR=~/pinokio/api/wan.git/app WAN_PYTHON=~/pinokio/api/wan.git/app/env/bin/python # --------------------------------------------------------------------------- # Asset library (consumed by as … [excerpt intentionally limited to avoid republishing a large script or identity-specific configuration; use the source link for the full public comment]
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/okmfzpq/
+### u/SelectionCalm70 — Addition or operator report
+
+- Score at capture: 1
+- Comment: that's a solid curated list
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/okhb3bc/
+### u/lavangamm — Addition or operator report
+
+- Score at capture: 1
+- Comment: this list is giving me fomo 😭😭
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/okhcw2d/
+### u/H4llifax — Addition or operator report
+
+- Score at capture: 1
+- Comment: I tried two links, both were broken. Is that a problem of the links or just on my side?
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/oki68ak/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 0
+- Comment: Which one's, they are working for me.
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/oki95e9/
+### u/H4llifax — Addition or operator report
+
+- Score at capture: 1
+- Comment: For example the bedtime stories one brought me to GitHub starting page
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/okigwgu/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 0
+- Comment: Let me have it go through and check it's links. Trying to do a skill for this has been a PITA. Total links in the megathread: 240 \- 161 specific links: ALL WORKING \- 79 generic placeholder links: ALL BROKEN The 130 specific GitHub repo URLs all resolve (200 OK). The 21 specific Reddit post URLs all resolve (301 redirect to [www.reddit.com](http://www.reddit.com), then 200). The 5 specific X/Twitter profile URLs resolve. The 1 Product Hunt URL resolves.
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/okij3zy/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 1
+- Comment: Links have been corrected or removed if the source could not be resolved.
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/okj04c7/
+### u/ShufflinMuffin — Addition or operator report
+
+- Score at capture: 1
+- Comment: Hot take: if you have to search for usages then you just don't have a usecase, and that's ok
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/okls4j2/
+### u/Sparescrewdriver — Addition or operator report
+
+- Score at capture: 2
+- Comment: You may have a certain usecase or problem but don’t realize Hermes has the capability to address it.
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/oklvbsr/
+### u/bezbol — Addition or operator report
+
+- Score at capture: 1
+- Comment: I hook it up with comfyui and 5090, now it can generate MV in 10minutes: ace step 1.5 for 3 minute song in 40 seconds, waiIllustrious for 10 pictures, and then hyperframes for added animation, ffmepg to combine everything to a music video!! All I have to do is tell it to generate an MV in certain style I want.
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/okmrlhf/
+### u/Professional_Car3334 — Needs verification
+
+- Score at capture: 1
+- Comment: If you're hitting rate limits scraping ecosystem data for these compilations, Qoest API's proxy rotation handled a similar batch job I ran last month without the usual headaches.
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/okovxwr/
+### u/Neither_Use8310 — Addition or operator report
+
+- Score at capture: 1
+- Comment: I used a proxy service once for a scraping project. Took longer to configure than the job itself.
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/okp19ow/
+### u/hermesagent-ModTeam — Addition or operator report
+
+- Score at capture: 1
+- Comment: Post removed for spam.
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/okp91nf/
+### u/rentprompts — Needs verification
+
+- Score at capture: 1
+- Comment: The 'Skill Factory' entry under Dev Workflow caught my eye — silently watching workflows and writing SKILL.md files. That’s the meta-layer I think most people miss: the agent isn’t just executing tasks, it’s encoding how it executes them so the next session builds on the last. That compounds faster than any single workflow tweak. Curious how many people here have actually set up skills that write other skills.
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/oozsq9b/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 1
+- Comment: I need to revisit skill formatting. I like to have my tools needed, exact paths to documents, etc. It needs to read like an SOP because I think that's where tool failure, hallucinations and loops start.
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/oozyskx/
+### u/cnplastminutelarry — Addition or operator report
+
+- Score at capture: 1
+- Comment: \[Use Case\] Restaurant AI Reputation & Content Agent — 90% auto, $299/mo service model What I built: A Hermes Agent nest for restaurants that handles the full reputation + content loop end-to-end. Built on Mac Mini M4 Pro (24GB), Telegram operator interface, 7 skills chained together: Google Places/TripAdvisor/Yelp review pull → sentiment + urgency classification → media library pull → AI image generation → caption writing → calendar scheduling → delivery. Operator only steps in for monthly check-in. The model: Productized recurring service — $299/mo per restaurant, 10% one-time setup, 90% automated delivery. One operator can run multiple accounts. What it actually does: * Pulls all new reviews daily across Google, TripAdvisor, Yelp * Classifies each review: thank-you response, complaint outreach, or feature-request content idea * Generates responsive social content automatically * Custom images/video generated per review context * Weekly content calendar + monthly performance report * Flags reputational streaks (bad review clusters) for human attention Why Hermes specifically: Persistent memory + skill-building means the agent learns each restaurant's brand voice and posting cadence over time. Telegram interface means restaurant owners review/approve from their phone — no new app onboarding. Numbers: * Setup time per client: \~90 min * Monthly operator time post-setup: \~30 min * Content volume: 15–25 pieces/week per location * Margin at 10 clients: \~$2,700/mo net after model costs Two other verticals in progress: * Sooner — AI Front Desk OS for reducing decision uncertainty * TIMELINE — animated sports magazine covers, Blender + MCP pipeline Photo below is the TIMELINE Wembanyama cover I just shipped — the same Hermes + Blender pipeline repurposed for a different domain. \[attach your image here when you post\] Question for the community: Right now I'm using Telegram inline buttons for batch approvals. Works but gets clunky above 10 pieces. Better … [excerpt intentionally limited to avoid republishing a large script or identity-specific configuration; use the source link for the full public comment]
+- Source: https://www.reddit.com/r/hermesagent/comments/1t6gf4j/megathread_hermes_agent_use_cases_what_the/oqnaifz/

--- a/references/reddit-comment-notes-integrations-plugins-skills-2026-06.md
+++ b/references/reddit-comment-notes-integrations-plugins-skills-2026-06.md
@@ -1,0 +1,73 @@
+# Reddit Comment Notes — Integrations, Plugins & Skills Ecosystem Megathread — Hermes Agent (June 2026)
+
+Original thread: https://www.reddit.com/r/hermesagent/comments/1ui5a91/integrations_plugins_skills_ecosystem_megathread/
+
+Captured for provenance during the July 16, 2026 migration. Classification is editorial triage, not independent verification. Promotional, reputational, pricing, benchmark, version, and availability claims require primary-source checks before entering the canonical guide.
+
+Praise, jokes, GIFs, removed/deleted bodies, bot reminders, and other non-substantive comments are intentionally omitted.
+
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 3
+- Comment: Also. [Welcome to R/HermesAgent Post Updated 6/28/26](https://www.reddit.com/r/hermesagent/comments/1tveg3d/welcome_to_rhermesagent_start_here/)
+- Source: https://www.reddit.com/r/hermesagent/comments/1ui5a91/integrations_plugins_skills_ecosystem_megathread/oud2ibi/
+### u/haltingpoint — Addition or operator report
+
+- Score at capture: 5
+- Comment: How is matrix nowhere in this list for messaging gateways? It is easily one of the most secure and private options and I have found clients more polished than signal for many core agent interactions.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ui5a91/integrations_plugins_skills_ecosystem_megathread/oudz3bg/
+### u/haltingpoint — Addition or operator report
+
+- Score at capture: 1
+- Comment: Lol, should maybe make that clearer in your post then
+- Source: https://www.reddit.com/r/hermesagent/comments/1ui5a91/integrations_plugins_skills_ecosystem_megathread/ouq888a/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 1
+- Comment: It's sooo clear, but I don't want to fight. I really want you to make a post. We have alot of good integrations but not enough people talking about it and i havent seen people talk about matrix in a hot minute. &gt;Built from subreddit discussions, X/Twitter, and official Hermes docs. &gt;This megathread is built from \~42 community threads, X/Twitter posts, and official Hermes docs from late April – June 28, 2026. Updated against v0.17.0 release notes (June 19, 2026). Key sources include: [r/hermesagent](https://www.reddit.com/r/hermesagent/) subreddit discussions
+- Source: https://www.reddit.com/r/hermesagent/comments/1ui5a91/integrations_plugins_skills_ecosystem_megathread/ouq9609/
+### u/Dharma_code — Addition or operator report
+
+- Score at capture: 1
+- Comment: Hermes suggested on being able to edit and configure automations on HA trough samba is this not the common route ? Sorry if I come off uninformed, I'm fresh to all of this. TYIA
+- Source: https://www.reddit.com/r/hermesagent/comments/1ui5a91/integrations_plugins_skills_ecosystem_megathread/oueomfy/
+### u/BestVersion01 — Addition or operator report
+
+- Score at capture: 1
+- Comment: Any love for Gbrain + Hindsight?
+- Source: https://www.reddit.com/r/hermesagent/comments/1ui5a91/integrations_plugins_skills_ecosystem_megathread/ouez20p/
+### u/riceinmybelly — Addition or operator report
+
+- Score at capture: 1
+- Comment: You’re using both? I’m all for redundancy but as far as I see, they do the same thing, I’m currently using hindsight but don’t have statistics yet on how much it really helped me as opposed to my obsidian vault.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ui5a91/integrations_plugins_skills_ecosystem_megathread/oufzhxf/
+### u/fishboneventures — Needs verification
+
+- Score at capture: 1
+- Comment: It's clear from this megathread that Hermes Agent is a seriously powerful system for anyone comfortable in the terminal, building custom tools, and managing their own servers. That kind of deep customization is fantastic for developers who want to own every part of their stack. But for business owners and teams who just need an operations coworker that lives where they already work (in Slack), connects in seconds without writing any code, and manages workflows with simple 1-tap approvals, that's a different game. That's exactly what Sterling CoWorker is built for. Think of it this way: Hermes, and other systems like OpenClaw, are like having a super-skilled developer on your team who can build anything you can imagine, but you need to speak their language (code, CLI). Lindy is a broad platform where you build your own agents from scratch, and Viktor (or Vik.ai) is often a highly specialized tool for one specific job, like accounting. Sterling CoWorker is your ready-to-go operations coworker, specifically designed for business tasks, living right inside Slack. Here's how we approach those business integrations you're looking at: * **Shopify, Klaviyo, QuickBooks, Ads (Facebook, Google):** Instead of building custom MCP tools or chaining together CLI commands, Sterling CoWorker connects directly to these services. You get a unified view and control right in Slack. For example, if you want to: * **Audit your Shopify store:** Ask Sterling CoWorker to check for low stock items, draft a restock order, and send it for your 1-tap approval in Slack. * **Manage Klaviyo campaigns:** Have Sterling CoWorker draft an email segment based on recent purchases, then review and approve the draft in Slack before it goes out. * **Keep QuickBooks tidy:** Ask for a summary of overdue invoices, or have Sterling CoWorker flag unusual expenses for your review. * **Monitor ad spend:** Get daily summaries of your Facebook or Google ad performance, with suggestions for budget adjustme … [excerpt intentionally limited to avoid republishing a large script or identity-specific configuration; use the source link for the full public comment]
+- Source: https://www.reddit.com/r/hermesagent/comments/1ui5a91/integrations_plugins_skills_ecosystem_megathread/ouftjnx/
+### u/ADtention — Addition or operator report
+
+- Score at capture: 1
+- Comment: Looking forward to see telegram doing incremental updates to their UX. I think they're moving to position themselves as the central interface between agents and humans.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ui5a91/integrations_plugins_skills_ecosystem_megathread/ouqe04i/
+### u/rittatewa — Correction or contradiction
+
+- Score at capture: 1
+- Comment: +1 to the folks asking for secret-management / password-manager style integrations here; adding the angle I keep landing on after trying to wire coding agents into real APIs. The useful pattern for me is not just “let Hermes fetch a secret from 1Password/Infisical.” That is better than pasting keys into config, but the agent still often ends up adjacent to the upstream credential. What I want in day-to-day use is scoped per-call access: agent -&gt; gateway/MCP endpoint -&gt; target API The agent gets an agent-scoped token. The gateway decides which service that token can call, resolves the right upstream credential, injects auth on the outbound request, and keeps the raw provider key out of the agent workspace/transcript/tool config. I’ve been working on this in NyxID. The README’s MCP setup flow is basically “add the downstream API once, point Claude Code/Codex/Cursor at /mcp.” In the backend, the credential injection path in proxy_service.rs handles the outbound auth, and AgentServiceBinding is the bit that lets one agent key map to a particular service credential instead of treating all agents as one vague user session. The failure-mode test I’d use for any Hermes integration is: can I revoke this one agent without rotating the real API key, and can two agents use different credentials for the same service? Open source repo: https://github.com/ChronoAIProject/NyxID
+- Source: https://www.reddit.com/r/hermesagent/comments/1ui5a91/integrations_plugins_skills_ecosystem_megathread/ourl2c7/
+### u/Patient-Analysis — Addition or operator report
+
+- Score at capture: 1
+- Comment: this is a lot of good info. the section on email and google banning accounts is pretty wild, did not realize that was such a big issue for agent use. makes sense though i guess the part about obsidian being the community standard for knowledge management for memory tiers is interesting. i'm always trying to figure out how to keep track of client discussions and deliverables. what about something like allsettled? i've used it for keeping track of scope stuff with clients, but i wonder if it could integrate with something like this for historical context on requests. like if an agent could pull from that to see what was agreed on
+- Source: https://www.reddit.com/r/hermesagent/comments/1ui5a91/integrations_plugins_skills_ecosystem_megathread/ousoiq6/
+### u/Difficult-Storage605 — Correction or contradiction
+
+- Score at capture: 1
+- Comment: Honestly, it's wild how big the Hermes skills and MCP ecosystem has gotten, but you've nailed the real issue for scaling up. The community's makeshift integrations and MCP tools for Shopify or Amazon work great for personal projects, but they can become a single point of failure when you're moving serious order or inventory volume. I've seen that scripted data flow turn into a full time job of manual fixes. We had to switch gears and started working with APIWORX last year. It's a different beast, built specifically for connecting storefronts and marketplaces to ERPs like NetSuite at an enterprise scale. The big difference is it runs on a serverless AWS backbone, so it just handles the transaction spikes automatically. For us, that meant we could stop babysitting our legacy integration scripts and actually focus on the business. The downside is it's absolutely overkill if you're just tinkering. It's built for when those MCP tools you mentioned start to max out and reliability becomes non negotiable. What's pushing you to look beyond the community built MCP tools? Is it about handling higher transaction volumes, or needing deeper resilience for your core business data?
+- Source: https://www.reddit.com/r/hermesagent/comments/1ui5a91/integrations_plugins_skills_ecosystem_megathread/ovlrefp/
+### u/AlexSt1975 — Correction or contradiction
+
+- Score at capture: 1
+- Comment: Thanks for maintaining this megathread — it’s already a really useful map for people extending Hermes. One addition that may fit is Hermes Local Knowledge, a plugin that gives Hermes a local capability index over local skills, scripts, runbooks, cron jobs, MCP servers, and docs, so it can find the right artifact first instead of guessing or grepping around. Repo: [https://github.com/stepanov1975/hermes-local-knowledge](https://github.com/stepanov1975/hermes-local-knowledge)
+- Source: https://www.reddit.com/r/hermesagent/comments/1ui5a91/integrations_plugins_skills_ecosystem_megathread/owiqacv/

--- a/references/reddit-comment-notes-kanban-setups-2026-06.md
+++ b/references/reddit-comment-notes-kanban-setups-2026-06.md
@@ -1,0 +1,58 @@
+# Reddit Comment Notes — Kanban Setups Megathread — Hermes Agent (June 2026)
+
+Original thread: https://www.reddit.com/r/hermesagent/comments/1ugkihk/kanban_setups_megathread_hermes_agent_june_2026/
+
+Captured for provenance during the July 16, 2026 migration. Classification is editorial triage, not independent verification. Promotional, reputational, pricing, benchmark, version, and availability claims require primary-source checks before entering the canonical guide.
+
+Praise, jokes, GIFs, removed/deleted bodies, bot reminders, and other non-substantive comments are intentionally omitted.
+
+### u/Jonathan_Rivera — Correction or contradiction
+
+- Score at capture: 13
+- Comment: # Added Bonus, What would Andrej Karpathy say about how to best utilize this setup. &gt;&gt;&gt;&gt; I don't think OP wrote this himself.. # Kanban, Profiles, and the Agent Loop — A Philosophy Check (Sticky) **A companion post to the Kanban Setups Megathread** There's a lot of energy around multi-agent setups right now. Six-profile pipelines. Orchestrators that decompose tasks. Fleet workers running overnight. It's exciting, and the megathread documents it well. But it's worth checking in with a simpler frame. This isn't a critique of Kanban — it's a reminder of what the agent loop actually is, and what happens when you abstract before you understand. --- ## The core loop is the real architecture Andrej Karpathy has been saying this for years, and it maps perfectly onto Hermes: &gt; The agent loop — **think → act → observe → repeat** — is the only architecture that matters. Everything else is papering over how well you do that loop. Before you add a second profile, ask: does your first agent complete one task reliably? Does it call the right tools, hand off cleanly, and stop when done? If the answer is "mostly" or "it depends on the model," another profile won't fix that. It will just make the failure more expensive because now two agents are failing in sequence. The dispatcher + Kanban worker lifecycle *is* the agent loop at the system level. You're not escaping the loop by adding profiles — you're just distributing it. That's fine when you've outgrown one agent. It's premature when you haven't. --- ## Every profile pays cold-start cost Each dispatcher spawn is a fresh process with a cold context window. The worker reads its task, loads parent handoffs, loads comments, loads skill files — all before it does any actual work. On a local model, that's seconds of overhead per spawn. On an API model, that's tokens burned before the first meaningful output. A single profile running 50 sequential turns costs less than 5 profiles running 10 turns each, because t … [excerpt intentionally limited to avoid republishing a large script or identity-specific configuration; use the source link for the full public comment]
+- Source: https://www.reddit.com/r/hermesagent/comments/1ugkihk/kanban_setups_megathread_hermes_agent_june_2026/ou0o32o/
+### u/Sr_Alu — Correction or contradiction
+
+- Score at capture: 3
+- Comment: Some more tips based on my experience: Give a worker either a worker specific [AGENTS.md](http://AGENTS.md) in its working dir, or implement some "standard handoff/working rules" document that get auto attached to the workers session. \- You want to explicitly tell it to use kanban complete when the task is done, because some models seem to forget this and then the card gets blocked even tho the work is actually done. \- Some LLM (especially GPT5.5) also tends to always actively block a task when it done for "human review". if you dont want that, tell it explicitly to not do this. \- You want to drastically increase all relevant Kanban/Hermes related Timeouts, that will reduce the card failure rate by prolly 90% lol \- If the worker is supposed to use an MCP, you also might want to increase the MCP tool call failure limit (default is 3) \- Regarding retries, its a good idea to let another model do the retry instead of the same one. Depending on what you do, many blockers might actually occur because a model downright refuses the task (ie for cybersec or NSFW reasons)
+- Source: https://www.reddit.com/r/hermesagent/comments/1ugkihk/kanban_setups_megathread_hermes_agent_june_2026/ou56gtf/
+### u/sbussiso_dube — Addition or operator report
+
+- Score at capture: 2
+- Comment: Thanks for all the info!
+- Source: https://www.reddit.com/r/hermesagent/comments/1ugkihk/kanban_setups_megathread_hermes_agent_june_2026/ou72gfg/
+### u/Proparser — Addition or operator report
+
+- Score at capture: 1
+- Comment: Its not cheap, with cloud api llm?
+- Source: https://www.reddit.com/r/hermesagent/comments/1ugkihk/kanban_setups_megathread_hermes_agent_june_2026/ou1wck8/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 1
+- Comment: I would imagine that your user. md is very serious while mine is literally modeled after iron man's AI assistant lol.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ugkihk/kanban_setups_megathread_hermes_agent_june_2026/ou25cbd/
+### u/Gnillort123 — Addition or operator report
+
+- Score at capture: 1
+- Comment: Is there such a thing in openclaw?
+- Source: https://www.reddit.com/r/hermesagent/comments/1ugkihk/kanban_setups_megathread_hermes_agent_june_2026/ou387dp/
+### u/rittatewa — Addition or operator report
+
+- Score at capture: 1
+- Comment: Same pain here from the Hermes setup angle: once Claude Code, Codex, Cursor, and n8n all share one upstream key, MCP tool wiring stops being just config and becomes an attribution problem. The hardening pattern I keep landing on is: do not give each runner the real OpenAI / Anthropic / GitHub key. Give each runner its own broker key, then let the broker inject the real downstream credential only on the proxy path. I've been working on an open-source version of that idea we're calling NyxID. The useful bit is not magic auth; it is the separation. In the model layer, `UserService` is the thing the agent is allowed to call, while `UserApiKey` is the encrypted downstream credential. In the proxy path, NyxID resolves the service, checks whether the agent key is scoped to it, decrypts the selected downstream credential, then the credential injection switch in `proxy_service.rs` applies it as bearer auth, custom header, query param, basic auth, etc. The part that mattered most for agent workflows was per-agent binding. Claude Code and n8n can both call the same logical `openai` service, but NyxID can inject different upstream keys for each agent. If the n8n workflow goes sideways, I can revoke that agent key or binding without breaking Claude Code, and logs can carry `X-NyxID-Agent-Id` for attribution. So my practical advice is: treat MCP/tool credentials as a routing boundary, not just env vars copied into every runner. Code is here: https://github.com/ChronoAIProject/NyxID
+- Source: https://www.reddit.com/r/hermesagent/comments/1ugkihk/kanban_setups_megathread_hermes_agent_june_2026/oua0205/
+### u/Page_Specialist — Addition or operator report
+
+- Score at capture: 0
+- Comment: precisamos disso no App desktop!!!
+- Source: https://www.reddit.com/r/hermesagent/comments/1ugkihk/kanban_setups_megathread_hermes_agent_june_2026/ou0upx2/
+### u/gigieazi — Addition or operator report
+
+- Score at capture: 0
+- Comment: LOVE kanban
+- Source: https://www.reddit.com/r/hermesagent/comments/1ugkihk/kanban_setups_megathread_hermes_agent_june_2026/ou0z648/
+### u/riceinmybelly — Addition or operator report
+
+- Score at capture: 1
+- Comment: Hehe saw your post, wanted to link you but you found it on your own
+- Source: https://www.reddit.com/r/hermesagent/comments/1ugkihk/kanban_setups_megathread_hermes_agent_june_2026/ou2fkdy/

--- a/references/reddit-comment-notes-mac-mlx-apple-silicon-2026-06.md
+++ b/references/reddit-comment-notes-mac-mlx-apple-silicon-2026-06.md
@@ -1,0 +1,203 @@
+# Reddit Comment Notes — Mac + MLX Megathread — Hermes Agent on Apple Silicon (June 2026)
+
+Original thread: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/
+
+Captured for provenance during the July 16, 2026 migration. Classification is editorial triage, not independent verification. Promotional, reputational, pricing, benchmark, version, and availability claims require primary-source checks before entering the canonical guide.
+
+Praise, jokes, GIFs, removed/deleted bodies, bot reminders, and other non-substantive comments are intentionally omitted.
+
+### u/dillpickle1621 — Addition or operator report
+
+- Score at capture: 8
+- Comment: Thank you for the write up, well done!
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot1zen8/
+### u/sickboy6_5 — Addition or operator report
+
+- Score at capture: 5
+- Comment: good write up. i'll have to check out rapid-mlx. have been using oMLX (M5) and have been pretty satisfied so far.
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot2e2lt/
+### u/PracticlySpeaking — Needs verification
+
+- Score at capture: 1
+- Comment: oMLX is pretty solid, and jundot (with a lot of contributors) is keeping up with the newest models and features. The benchmarking and hot/cold prompt caching really launched its popularity, but there is something new every week.
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot7zuk9/
+### u/JBManos — Addition or operator report
+
+- Score at capture: 1
+- Comment: That’s what I use and I have lm studio sitting around as a fallback just in case or I switch over to lm studio and tell Hermes to update mlx then switch back to omlx after update.
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot8wauv/
+### u/beheks — Addition or operator report
+
+- Score at capture: 3
+- Comment: Thanks for this! Have you tried antirez's DwarfStar (https://github.com/antirez/ds4)? Wondering how it compares to rapid-mlx in terms of tool-calling reliability and speed on Apple Silicon.
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot3cm7p/
+### u/Fabulous-Ladder3267 — Addition or operator report
+
+- Score at capture: 3
+- Comment: I love you, thank you very much
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot24wxl/
+### u/longpos222 — Addition or operator report
+
+- Score at capture: 2
+- Comment: Appreciated it
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot25jp9/
+### u/challis88ocarina — Addition or operator report
+
+- Score at capture: 2
+- Comment: If you use the same machine for Hermes and your backend, avoid the desktop app, which castrates your GPU. The chat in the Dashboard is a welcome addition, although when I'm on the same machine, it's TUI only.
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot2ckb6/
+### u/PracticlySpeaking — Addition or operator report
+
+- Score at capture: 2
+- Comment: ✊ TUI solidarity
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot80baf/
+### u/internetisforlolcats — Addition or operator report
+
+- Score at capture: 2
+- Comment: This was good, thank you!!
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot2cxad/
+### u/a7g4 — Addition or operator report
+
+- Score at capture: 2
+- Comment: Has anyone tried using Apple Container, introduced in macOS 26(Tahoe), to install Hermes?
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot2f94q/
+### u/JaySomMusic — Needs verification
+
+- Score at capture: 1
+- Comment: taOS uses Apple containers to isolate agents and it works great https://github.com/jaylfc/taOS
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ou0q2aa/
+### u/scattered-thunder — Addition or operator report
+
+- Score at capture: 2
+- Comment: Holy moly. Doing the lord’s work! Thank you!
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot3wij2/
+### u/PracticlySpeaking — Addition or operator report
+
+- Score at capture: 1
+- Comment: This is what agents are all about!
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot7zycw/
+### u/LoveRoboto — Addition or operator report
+
+- Score at capture: 2
+- Comment: "Qwen models are known to overthink on even the simplest prompts." Tell me about it—the speed is unmatched; pray you ask questions properly or pay! Thanks for the Gemma 4 recommendation—it thinks through problems more smoothly than Qwen3.6-35B-A3B. I'll see if it spirals into death loops; so far, so good.
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/otdiwzv/
+### u/ZioniteSoldier — Addition or operator report
+
+- Score at capture: 1
+- Comment: Out here doing the lords work. Excellent writeup
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot23fx4/
+### u/FilterJoe — Addition or operator report
+
+- Score at capture: 1
+- Comment: Great discussion on installing models. What about installing Hermes? Safe options are docker or VM. I am curious if anyone has success running Hermes on a VM on a Mac while accessing the host Mac server running the model. You could also run a model within Linux VM but at slower speeds.
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot28qy1/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 9
+- Comment: Your going to spoil the surprise. That’s already ready to drop between now and Wednesday. 😉
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot29jwp/
+### u/FilterJoe — Addition or operator report
+
+- Score at capture: 2
+- Comment: I will be reading that one for sure! I currently only have an M2 Mac mini Pro with 16 GB RAM. I have been running Hermes on my VMware fusion Debian VM. It works fine but I don’t have enough space left for a local model that is powerful enough for Hermes. I’m getting a Mac with much more memory a few weeks from now and I’m very much hoping to run a setup with Hermes on Debian VM but local LLM model on the Mac host.
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot2ai7y/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 3
+- Comment: I’ll drop it tomorrow afternoon. I have a few lined up for the week on different high frequency topics.
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot2ayf3/
+### u/riceinmybelly — Addition or operator report
+
+- Score at capture: 1
+- Comment: Ooh, I’m just installing Linux on an old Dell, can’t wait
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot2t6ry/
+### u/Unixwzrd — Needs verification
+
+- Score at capture: 1
+- Comment: I've done this using UTM. Works great. Run the models on my machine and Hermes in its own VM with its own IP and everything. UTM is free and open source, but it's available through the app store for a small price. I opted for the app store for expediency and not having to build it myself. Plus it gets updates. It's one of the better virtualization stacks out there because it takes advantage of Apple's Virtualization Framework.
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot554cs/
+### u/FilterJoe — Needs verification
+
+- Score at capture: 1
+- Comment: Terrific! VMware fusion is free too but it's not open source and Broadcom has the craziest most confusing system for getting to the free download. But once you get there and download it, it works. Do you run local models? If so, are you running the local model within the VM or on the host Mac? And if you're running it on the host mac as a server, how did you get the VM to see the server?
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot5mewb/
+### u/Unixwzrd — Addition or operator report
+
+- Score at capture: 2
+- Comment: Yes I have a model for inference with vision - Qwen3.6 35B A3B -several, I’m doing some testing. The I have BGE-m3 for embedding. And a Qwen3 TTS which supports voice cloning. I had to fiddle with the voice cloning a bit, but I also built a TTS-Bridge which maps a voice name to a voice sample on the server. It’s in my very messy LLM-Ops-Kit, but some useful things in there. I’ve been meaning to release a new version which is better organized. The models are running natively on the Mac and Hermes Agent is in the VM’s. The nice thing you can do with this if you have Tahoe, you can put the system disks on an external drive. The agent really doesn’t need the speed over the model. I actually shelled out the small amount for the App Store version of UTM because I have a lot I’m doing and didn’t want to spend a few days getting it compiled and installed. Getting it in the App Store I also get updates automatically. UTM was a great find. I usually use Virtual Box, but UTM takes advantage of the virtualization Framework. You can even back a VM up to network storage (host machine mounted) using Time Machine.
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot6jek4/
+### u/Stooovie — Addition or operator report
+
+- Score at capture: 1
+- Comment: Great writeup that mirrors my own experiences. RapidLLM 2-3x claims are nonsense though. It is marginally faster, in some cases. Also Qwen 35b a3b is pretty heavy heavy for 36GB RAM, and unusable on 32.
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot2h9t0/
+### u/lord_zunami — Addition or operator report
+
+- Score at capture: 1
+- Comment: Wow Thanks 👍👍👍
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot2ketz/
+### u/47rrr — Addition or operator report
+
+- Score at capture: 1
+- Comment: thanks a lot for this
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot2lysq/
+### u/heresmything — Addition or operator report
+
+- Score at capture: 1
+- Comment: I'm using MLX Qwen3.6 and I learned a lot here!
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot2u9cx/
+### u/Bayward_Bound — Addition or operator report
+
+- Score at capture: 1
+- Comment: It’s really helpful. Thanks a lot.
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot35a7r/
+### u/Nicolinux — Addition or operator report
+
+- Score at capture: 1
+- Comment: Super helpful, thanks! According to these findings, what would you recommend for a personal knowledge management (in Obsidian) where the model has to decide where to sort new bits of information inside the existing Obsidian vault? Running on a Mac Mini M4 with 16GB RAM. Use Qwen3.5-9B Q4\_K\_M with quantized KV cache or the new Gemma 4 12B?
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot37w2o/
+### u/gladkos — Addition or operator report
+
+- Score at capture: 1
+- Comment: Great review, thank you! One thing worth mentioning is [Atomic.Chat](http://Atomic.Chat) \- it works similarly to Ollama, but supports Google TurboQuant, allowing much larger context windows for long-running agentic tasks
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot3gec1/
+### u/stackfullofdreams — Addition or operator report
+
+- Score at capture: 1
+- Comment: Excellent work!
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot3qbeb/
+### u/Pretend-Gur-2883 — Addition or operator report
+
+- Score at capture: 1
+- Comment: https://github.com/HenryLinyy/Conclava Cool fusion gateway,check this out.
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot44jxo/
+### u/Critical-Cheetah650 — Addition or operator report
+
+- Score at capture: 1
+- Comment: Ollama launch hermes
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot4b5v1/
+### u/JLeonsarmiento — Addition or operator report
+
+- Score at capture: 1
+- Comment: NEX-N2- mini is what you should be using.
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot5husb/
+### u/PracticlySpeaking — Addition or operator report
+
+- Score at capture: 1
+- Comment: &gt;**Q: Should I use Hermes for coding on a local Mac?** A: The community is split. Some (including the "Running Locally, Really?" OP) say "Hermes is not for coding — it's an orchestration agent. Use Claude Code or OpenCode as a sub-agent." It is worth noting a bit of history here — Hermes Agent is an evolution of Nous Research internal coding tools. It has always been about coding... and now, so much more.
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot7z5l4/
+### u/JBManos — Needs verification
+
+- Score at capture: 1
+- Comment: Just want to add that OMLX with MTP on has resulted in fastest generation for me run the qwen3.6-35b on it and hover around 70 tok/s generation. Add in the prompt caching and nothing can beat it.
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ot8w3bp/
+### u/k0pzy — Addition or operator report
+
+- Score at capture: 1
+- Comment: Thanks! Very helpful.
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/otm0h0s/
+### u/Choice_Letter_5912 — Addition or operator report
+
+- Score at capture: 1
+- Comment: Holy fuck dude. Write a book
+- Source: https://www.reddit.com/r/hermesagent/comments/1uc7rw5/mac_mlx_megathread_hermes_agent_on_apple_silicon/ou8fys8/

--- a/references/reddit-comment-notes-models-providers-plans-2026-07.md
+++ b/references/reddit-comment-notes-models-providers-plans-2026-07.md
@@ -1,0 +1,218 @@
+# Reddit Comment Notes — Models, Providers & Plans Megathread — June 2026
+
+Original thread: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/
+
+Captured for provenance during the July 16, 2026 migration. Classification is editorial triage, not independent verification. Promotional, reputational, pricing, benchmark, version, and availability claims require primary-source checks before entering the canonical guide.
+
+Praise, jokes, GIFs, removed/deleted bodies, bot reminders, and other non-substantive comments are intentionally omitted.
+
+### u/Jonathan_Rivera — Needs verification
+
+- Score at capture: 3
+- Comment: * I don't think the MiniMax $10 plan exists anymore, substituted with a $20 plan [https://platform.minimax.io/docs/guides/pricing-token-plan](https://platform.minimax.io/docs/guides/pricing-token-plan)u/filthpig999 * The "no caching - burns through tokens" for Xiaomi Mimo is incorrect, that's only through OpenRouter (I found out the hard way). If you go directly to their API, their caching is just as good if not better than DeepSeek. u/Taegost
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/otxw7b4/
+### u/tomorrowplus — Addition or operator report
+
+- Score at capture: 12
+- Comment: Please do a megathread on Kanban setups (profiles, souls, configs, models, tools/skills, params).
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/otwat0w/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 3
+- Comment: I don't know much about Kanban yet but I'll give it a go.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/otyrpwi/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 4
+- Comment: [The Kanban Megathread and it's all u/tomorrowplus fault lol](https://www.reddit.com/r/hermesagent/s/CzSSv8zGCx)
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/ou0omcc/
+### u/filthpig999 — Needs verification
+
+- Score at capture: 8
+- Comment: I don't think the MiniMax $10 plan exists anymore, substituted with a $20 plan https://platform.minimax.io/docs/guides/pricing-token-plan
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/otv2a3p/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 2
+- Comment: Good catch, this shows how quickly things change in this space.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/otxvohv/
+### u/francxsim — Addition or operator report
+
+- Score at capture: 1
+- Comment: The Minimax $10 token was taken down when Minimax m3 was released on 1 June.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/ou9uldx/
+### u/yhsong1116 — Addition or operator report
+
+- Score at capture: 1
+- Comment: Dang that sucks
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/otvidah/
+### u/filthpig999 — Addition or operator report
+
+- Score at capture: 1
+- Comment: would love to be proven wrong... anyone with a SPECIAL FRIENDS code that gives access? haha
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/otvj9n3/
+### u/Sr_Alu — Needs verification
+
+- Score at capture: 6
+- Comment: Great list, great effort, much appreciated. I believe this is too much focus on "budget" tho. I know chinese models get lots of love and they do so for a reason, but truth is if you actually want your agent(s) to do heavy work RELIABLY, then ChatGPT 200 bucks subscription outperforms everything else by a long shot. Like, its not even remotely close, not even (or especially..) compared against the "best overall" deepseek. Considering deepseek as best overall is just not true. Looking into the newer, more difficult benchmarks, the difference between GPT and Claude on the one side and the chinese models on the other side is absolutely staggering, with only GLM5.2 coming somewhat close (but only somewhat). The ChatGPT 200 plan also gives basically unlimited access to GPT5.4 mini and GPT5.3 codex spark, plus unlimited image generation, plus vision. GPT5.5 has fixed so much mess for me that chinese models have created, no matter if deepseek, minimax, mimo, kimi or whatever, its not even funny anymore. If you are serious and can/want to afford it then ChatGPT 200 IS the only way. Otherwise i would say 20 bucks ChatGPT for heavy lifting plus Minimax 20 bucks is the way. Minimax M3 is way better than Deepseek 4 pro/flash too and the 20 bucks plan is indeed virtually unlimited. Plus it gives you unlimited decent TTS, vision and (crappy) imagegen too. Why so much undeserved love for Deepseek? The V3 and R1 days are long over...
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/otx6m43/
+### u/remyrah — Addition or operator report
+
+- Score at capture: 1
+- Comment: Please share your setup that just uses your ChatGPT pro 20x plan
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/ou42x64/
+### u/Sr_Alu — Addition or operator report
+
+- Score at capture: 3
+- Comment: I dont use exclusively use the 20x plan. I also have super grok and the minimax 20 bucks coding plan for more TTS/Imagegen/Vision options and fallback in case GPT is down. Always some bucks on Nous portal for experiments too, but not used in daily operations. Everything else goes through the 20x plan.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/ou540r0/
+### u/mia6ix — Addition or operator report
+
+- Score at capture: 1
+- Comment: Thank you so much for this - exactly what I needed. I’ve arrived here from a personal Claude 20x max plan and I have been in analysis-paralysis over these model conversations.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/ov2qv9v/
+### u/Sr_Alu — Addition or operator report
+
+- Score at capture: 2
+- Comment: been there too. if you come from claude 20x then gpt 20x should be a no brainer for you imho, unless your main goal is cutting cost. as backup i would recommend the 20 bucks minimax coding plan for "meh, but at least its basically unlimited" performance, or ollama cloud for GLM5.2 and some other models for aux tasks to save on GPT quota
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/ov6a1u8/
+### u/Avecfort — Addition or operator report
+
+- Score at capture: 1
+- Comment: I just got this to give it a try and maxed out rather quickly, but it's the 20usd plan. Do you know if it's a rolling 3 or 5h window since I'm getting mixed information about this. Acording to /usage it's 5h. Also can I put it on mini and that will apply differently to my usage quota or is it amount of messages no matter what model or how many tokens you put into them? Have you had issues with too many requests too quickly making it time out? any other things worth knowing about how the subscription works?
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/ovh0pms/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 0
+- Comment: Good questions. Something like this comes up on every megathread and my immediate thought is, "You have to read the room." The direction of the megathread comes from the aggregation of comments on the sub and only then does the research outside the sub occur. From this you can infer that the majority of the subreddit users are either on a budget and/or people who use GPT 5.5 are not very vocal in posts. That and Open AI has had the same issues as anthropic, I'm within my budget and then suddenly I am burning through it at 2x the rate. Certainly GPT 5.5 is a very capable model, but people are trying to do more with less. You start adding in agentic loops into long complex tasks and even the $200 plan will get eaten away.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/otxv5pq/
+### u/NousResearch — Addition or operator report
+
+- Score at capture: 3
+- Comment: New Megathread dropped!
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/otvjpas/
+### u/ChemicalNo9880 — Addition or operator report
+
+- Score at capture: 3
+- Comment: Crazy - I've been manually looking at all these threads like a peon. Thanks for compiling this for us! Has anyone looked into using Manifest ([https://github.com/mnfst/manifest](https://github.com/mnfst/manifest)) as a additional routing layer? In addition, has anyone been using an ACP to proxy in their Claude Code subscriptions for Hermes? I have the really expensive plan (for work) and I never find myself hitting limits; I understand it would be silly to route everything to this plan because the heartbeats will be a huge give away but it would be nice if I could delegate coding this way, without getting banned of course. If it is too risky, I am likely going to switch to OpenAI, but I prefer Anthropic as a company both on their models and ethics, such a shame they've put their foot down on third party stuff because of OpenClaw. E: Well I tried Manifest, couldn't work out how to set up the 'complexity' routing seemed to only offer default + fallback routing, which Hermes handles anyway so I dropped it.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/otwdnaj/
+### u/laontme — Addition or operator report
+
+- Score at capture: 2
+- Comment: manifest seems like a good fit for me, will try it out, btw you can check out litellm adaptive router and bifrost complexity router
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/otz37qr/
+### u/purple621 — Addition or operator report
+
+- Score at capture: 3
+- Comment: why is Xiaomi MiMo no caching? Using it via openrouter API provider xiaomi and the caching works fine. Cost is almost non existent on multiple turns. set my cache ttl from 5m to 1h though.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/oubhkd7/
+### u/Taegost — Addition or operator report
+
+- Score at capture: 2
+- Comment: The "no caching - burns through tokens" for Xiaomi Mimo is incorrect, that's only through OpenRouter (I found out the hard way). If you go directly to their API, their caching is just as good if not better than DeepSeek. I've been using it heavily for two weeks now and my cache hit rate is about 95%. The only reason it's that low is because I recently started using Hermes and I've been feeding it a ton of data.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/otx9zay/
+### u/naes993 — Addition or operator report
+
+- Score at capture: 2
+- Comment: I literally just started using Hermes two days ago, and I've spent the past two days trying to figure out exactly what you just did... Thank you 🙏
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/ou0q7od/
+### u/Jonathan_Rivera — Correction or contradiction
+
+- Score at capture: 1
+- Comment: We all start in the same spot. You should have seen my megathreads 3 months ago when I first started, mistakes, broken links etc. Overtime you gain experience, refine your skills and then in a month or two you'll be the one helping people. Enjoy!
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/ou0u7mj/
+### u/GuesswhoisAI — Addition or operator report
+
+- Score at capture: 2
+- Comment: \&gt;**Two-tier routing: cheap orchestrator + expensive powerhouse.** Flash for 90% of tasks, Pro/Codex only for complex work. Saves 5-10x. Can someone define what are considered cheap orchestrator task and which are expensive powerhouse? Is architecture review/ self review flash category, or pro? I am burning about 4-6 dollars a day with deepseek pro direct api credits, and that's even with my having most jobs on python, context governors and stuff like that. I also try to use codex where i can for architecture and coding stuff, but chatgpt plus oath limits suck. Also, is opencode worth it for me? Also I've saw [openlimits.app](http://openlimits.app) on reddit, has anyone tried it, is it worth it?
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/ou3jhvt/
+### u/EnigmaCrypto — Addition or operator report
+
+- Score at capture: 2
+- Comment: Top read, thank you for sharing 🙏
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/ou43vr0/
+### u/Perfect-Drive451 — Addition or operator report
+
+- Score at capture: 2
+- Comment: I've been developing an app pretty reliably. My orchestrator is ChatGPT 5.5 (via app) connected to Slack. It's connected to Hermes agent via Slack in a development common channel. Hermes is running Grok Composer 2.5 flash via xAI Grok OAuth (SuperGrok / Premium+). Both Hermes and ChatGPT are connected to GitHub and able to push/pull/merge repos. I just babysit the orchestrator, it makes sure that Hermes does verifications and checks before every PR. Pretty much autopilot. Haven't ran into any throttling or surprises yet. Composer 2.5 flash is surprisingly good (probably has to do with Hermes skills) and fash. Completing the same tasks as MinMax at a fraction of the time. The project I'm working on is [Thalean Space](https://thaleanspace.com/) My overall costs are: ChatGPT subscription $20/mo; Supergrok subscription $30/mo; Hermes Nous Portal subscription $20/mo; GitHub + Copilot pro+ subscription $39/mo $100/mo for all the AI I need to run a business
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/ou93a75/
+### u/spacenglish — Needs verification
+
+- Score at capture: 1
+- Comment: How to rate limit queries on certain models like Gemini? I edited yaml config but it doesn’t seem to respect it. Here is the
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/otvm4yu/
+### u/Fair-Perspective7352 — Addition or operator report
+
+- Score at capture: 1
+- Comment: Been routing between local and cloud models lately. The sweet spot for me is running smaller models (7-13B) locally for quick coding tasks, then escalating to API calls only when I need reasoning depth. Saves a ton on tokens and latency is surprisingly good with quantized weights.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/otvn1db/
+### u/Bitter-College8786 — Correction or contradiction
+
+- Score at capture: 1
+- Comment: Great Thread, OP. One thing: MiMo Token Plan works with "credits", where cache Hit tokens consume 1-2 credits, but cache miss tokens around 100. And MiniMax Token Plan Starter (10$) is no longer available, you have to use the 20$ Pro one
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/otw8oyz/
+### u/tomorrowplus — Addition or operator report
+
+- Score at capture: 1
+- Comment: Deepseek pro and flash are both recommended as orchestrator. It seems like a high importance task, but maybe it’s not so complicated? Which one?
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/otwacnt/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 2
+- Comment: Remember it's pulled from different posts and use cases. Myself personally I use Deepseek Pro for the orchestration and flash for the subagents to do the research and aggregation for these Megathreads. There are other users that like to use flash with high reasoning saying it comes close to pro for a fraction of the cost. It really depends on the complexity of your project.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/otxsl7j/
+### u/osvuldo77 — Addition or operator report
+
+- Score at capture: 1
+- Comment: Amazing share! Thank you OP! What a resource for all of us to use.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/otxrluv/
+### u/Longjumping_Soil2116 — Addition or operator report
+
+- Score at capture: 1
+- Comment: I doubt there's anyone else out there trying it out, but Grok 4.3 is a strange one. On High Reasoning it's unusably bad, but on Low Reasoning its surprisingly capable. I wouldn't drop any other model for it, and GPT-5.5 absolutely laps it in every regard. But if you happen to have access to it and have run low on tokens/credits elsewhere, then Grok 4.3 Low is a serviceable stand in.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/otyjvsx/
+### u/[deleted] — Needs verification
+
+- Score at capture: 1
+- Comment: What about [https://perchai.app/pricing](https://perchai.app/pricing) the $10 pro plan, anyone try using it specifically with Hermes?
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/ou0kvc5/
+### u/hubertron — Addition or operator report
+
+- Score at capture: 1
+- Comment: No having 5.2 and main orchestrator here is a miss
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/ou1yq55/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 1
+- Comment: Please explain for everyone. There are always people that mention a model or provider but the thing is this is aggregating information. You all have to be more vocal about the models you like, if you don't talk about it, the model will not pick it up in the megathreads.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/ou270w7/
+### u/hubertron — Needs verification
+
+- Score at capture: 1
+- Comment: Totally fair. I wish we had a shared way to benchmark in this subreddit, or like a monthly survey.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/ou2dajg/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 1
+- Comment: If you create the questions I'll set up the google form or notion form and we can put it out monthly. Just shoot me a dm.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/ou2fb7p/
+### u/carlosm_sz — Addition or operator report
+
+- Score at capture: 1
+- Comment: What about GLM 5.2? 5.1 is mentioned above, but not 5.2… I’m using it through Z.ai subscription and it feel excellent. Thanks!
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/ovltagj/
+### u/yhsong1116 — Addition or operator report
+
+- Score at capture: 0
+- Comment: What’s the cheapest way to use deepseek v4 pro ? I’ll use for simple coding (fewer than 1k lines per “app”) and I already have grok. I’m planning to let a few of my coworkers try agentic coding through Discord and I doubt my grok premium + subscription will be enough.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/otvinab/
+### u/vladutzbv — Addition or operator report
+
+- Score at capture: 1
+- Comment: Did you read the post? Direct API
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/otwi21r/
+### u/yhsong1116 — Addition or operator report
+
+- Score at capture: 1
+- Comment: I meant to ask. With Zdr (zero data retention through open router) or otherwise private
+- Source: https://www.reddit.com/r/hermesagent/comments/1ufrtsf/models_providers_plans_megathread_june_2026/ou93s0l/

--- a/references/reddit-comment-notes-multi-agent-profiles-2026-06.md
+++ b/references/reddit-comment-notes-multi-agent-profiles-2026-06.md
@@ -1,0 +1,168 @@
+# Reddit Comment Notes — Multi-Agent & Profiles Megathread — Hermes Agent (June 2026)
+
+Original thread: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/
+
+Captured for provenance during the July 16, 2026 migration. Classification is editorial triage, not independent verification. Promotional, reputational, pricing, benchmark, version, and availability claims require primary-source checks before entering the canonical guide.
+
+Praise, jokes, GIFs, removed/deleted bodies, bot reminders, and other non-substantive comments are intentionally omitted.
+
+### u/riceinmybelly — Addition or operator report
+
+- Score at capture: 8
+- Comment: Ooh I’m feeding this into my setup right meow
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/ot5301g/
+### u/Nicolinux — Addition or operator report
+
+- Score at capture: 3
+- Comment: How would you use that with two distinct people? Create a profile for each? Or is it better to deploy two hermes agent instances?
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/ot5dkce/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 2
+- Comment: I’m doing this for the wife soon but I think it’s going to be just a profile.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/ot5huiw/
+### u/Nicolinux — Addition or operator report
+
+- Score at capture: 1
+- Comment: Yes same here. The problem I see is that profiles do not isolate the agents completely. I don't know what unexpected actions the other profile might perform which might jeopardize the entire installation (more than it does anyway...)
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/ot7dm4i/
+### u/flairtestuser123 — Addition or operator report
+
+- Score at capture: 2
+- Comment: Do you have the delegate/kanban headings swapped on Part2 table?
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/ot5cmld/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 1
+- Comment: Go ahead and quote the part and ill check it.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/ot5d7dx/
+### u/flairtestuser123 — Addition or operator report
+
+- Score at capture: 2
+- Comment: Why Kanban beats delegate_task for durable work: delegate_task Kanban Durability Lost if parent is interrupted Human in loop Not supported Multiple agents per task One subagent Audit trail Lost on compression Resumability None — failed = failed
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/ot5jlj9/
+### u/Jonathan_Rivera — Correction or contradiction
+
+- Score at capture: 1
+- Comment: Yep, good catch, it’s not swapped so much as missing the left “Criterion” column, which made Reddit render the delegate\_task limitations under Kanban. I’ll fix that table. Thanks for catching it.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/ot5kuhw/
+### u/Every-Equipment-3795 — Addition or operator report
+
+- Score at capture: 1
+- Comment: I was about to ask the same but you beat me to it
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/ot5mir4/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 1
+- Comment: For some reason when put everything in markdown, It would not let me post unless I converted back into rich text.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/ot5n43a/
+### u/Every-Equipment-3795 — Addition or operator report
+
+- Score at capture: 1
+- Comment: That's frustrating. Regardless of that mix up - Thank you for this post! It's an excellent guide and I've been searching for information like this. I should've led with that
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/ot600sh/
+### u/Paradigmind — Addition or operator report
+
+- Score at capture: 2
+- Comment: Are you using Hermes Desktop? Because for me the bot tokens are not isolated in the GUI.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/ot5l9mu/
+### u/arunsampath — Addition or operator report
+
+- Score at capture: 2
+- Comment: Same
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/oth88mn/
+### u/xeeff — Addition or operator report
+
+- Score at capture: 2
+- Comment: this might be your longest post yet 😆 awesome guides like always
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/otaljt9/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 1
+- Comment: No, there's 1 where I had to post the rest in the comments 2x and sticky it lol
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/ottzxc7/
+### u/djseto — Correction or contradiction
+
+- Score at capture: 2
+- Comment: Lot to digest here. So...what I deally want is one agent I talk to that is more conversational/generic. If during that conversation, the agent decides it needs to write code, I want it to talk to/spawn another agent who's my coder agent to delegate the work. Which is the best way to build this? For example, earlier today i asked Hermes to use Vane (running in Docker) to go research some stuff on the web. It didnt work because of a config change. After lots of back and forth, we found the issue in a python script so it wanted to fix the script. That's when things went sideways and I wonder if it was because I didn't have a coding defined agent (different temp etc.) do take on that task. Am I making any sense? Is that profiles? Is that delegate task? I dont want to tell the primary agent who to delegate to. I want it to decide based on the task (e.g. if we have to fix code, use the code agent).
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/ou1z5v6/
+### u/Jonathan_Rivera — Correction or contradiction
+
+- Score at capture: 1
+- Comment: Your problem isn't architecture. It's context. A separate agent with different temperature wouldn't have saved you. The model didn't have the right context: what broke, what to preserve, what the expected behavior was. LLMs are like people. You manage them the way you'd manage a person: give them clear instructions, the right context, and the right tools. You don't hire a separate "typing specialist" with a different personality for every subtask. You don't need a separate coding profile with different temperature. Hermes already has delegate\_task built in. The primary agent can spawn subagents with coding tools when it decides the task calls for it. This is exactly how Claude Code subagents work, the main agent reads the subagent's description and decides when to delegate. What you actually need: 1. One conversational agent 2. A system prompt rule: "when a task requires nontrivial code changes, spawn a subagent with terminal + file tools" 3. The subagent gets isolated context, does the work, returns the result 4. If things go wrong, fix the context you're passing to the subagent, not the architecture You're 90% there and overthinking the last 10%. The config change debugging saga wasn't an architecture gap, it was the model working with incomplete information about what had changed and what needed preserving. Better prompts, not more agents. Now I would consider having a verifier/critic pass on important outputs. or as they would call it a loop. Generate with one session, review with another. That's a more of a quality gate, not a different-temperature "coder personality." Same model, fresh eyes, strict critique prompt.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/ou23hwc/
+### u/djseto — Correction or contradiction
+
+- Score at capture: 1
+- Comment: I’m running qwen3.6 35b a3b using Ollama . The mega thread you have on Mac says for coding work the temp should be .6. For conversation etc it should be .8-1. How does Hermes know to spawn a coding agent with the right temp for coding work? To be clear, I’m not a developer so I was letting Hermes fix the script because it decided to. It figured out the issue and the decided to fix it. It just got stuck in some loop and eventually knew it was going down a rabbit hole and stopped itself and tried to start over.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/ou273e8/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 2
+- Comment: That is the rough part of local that I run into. Ideally you would run a 2nd model but on a mac you probably don't have the space. Consider using deepseek API for delegated tasks, $10 would last a while if your not using it frequently.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/ou28iq8/
+### u/djseto — Addition or operator report
+
+- Score at capture: 1
+- Comment: Then how do I tell Hermes to use a different model for coding agent? Is that the profile method?
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/ou28n9e/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 2
+- Comment: You can assign a model to subagents or you can create another profile.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/ou2a40x/
+### u/blackhawk00001 — Correction or contradiction
+
+- Score at capture: 1
+- Comment: Nice, I've been putting together a coordination framework with memory for pulling together various agent frameworks. I like this approach. Does your framework allow for configuring various local gpu inference endpoints for profiles/agents? I've taken a break from the other project to play with hermes and began working on extending the base subagent provider system to support routing to various local servers based on round-robin or semantically matched for purpose with thread queueing for limited concurrency. It's working but I'm ironing out bugs while getting a feel for the codebase.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/ot55yhb/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 3
+- Comment: The megathreads are more scraping community questions and pairing with answers along with data collection/research on the topics. I use these just like you to see what the next step would be. My workshop posts are things I have already implemented.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/ot56n5c/
+### u/leggomycraiggo — Addition or operator report
+
+- Score at capture: 1
+- Comment: Any advice for using this setup when you want to have Hermes call different models for different purposes? For instance, in the "personality split" setup, is it possible to have the one Hermes agent that uses a dense LLM for coding tasks while having a more nimble MOE for testing?
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/ot5pj4e/
+### u/banditjackpotty — Addition or operator report
+
+- Score at capture: 1
+- Comment: I haven't done it but it seems possible in my set up. You just set the other profile with another model. For coding, I have mine set up to pass off to Claude code instead
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/ot9mc70/
+### u/russjr08 — Addition or operator report
+
+- Score at capture: 1
+- Comment: Yeah, profiles can be set to run on different models - my "general" one for example uses DS v4 Flash, while my pair programming one is setup for GPT 5.5 There's a few options here that I'd investigate for this sort of thing. I believe the `delegate_task` tool that the agents have by default just make a temporary "clone" of itself, but you could probably have your agent instead use the `hermes --profile name --oneshot Prompt For Task Goes Here` command to do the delegation instead. That's hermes' equivalent of claude -p that some people do. Alternatively if you don't want to have a separate profile, you can still have the agent use that oneshot command with a model/provider override instead like `hermes --provider openai --model gpt-5.5 --oneshot PROMPT` which would spawn a temporary instance of the same agent for the new task, but with a different model loaded. Another option is to just [override the model that the delegation tool creates](https://hermes-agent.nousresearch.com/docs/user-guide/features/delegation/#model-override) via the config file, but that would apply to all delegations. In that case you could have your agent's main model be the lighter one, and then just instruct it for all coding tasks to be delegated out (and you'd set your dense model as the delegation model). Edit: Oh and of course, Kanban can probably be used for this too.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/oticlsy/
+### u/leggomycraiggo — Addition or operator report
+
+- Score at capture: 1
+- Comment: Brilliant, thank you for the quick walkthrough!
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/otino2k/
+### u/jaybsuave — Addition or operator report
+
+- Score at capture: 1
+- Comment: think i will run this in the background on files that i consider finish, so like a constant code review on files and then allow a multi agent hermes worflow completely commit to code review after running multiple agents through opencode.. trying to figure out how to work this into my workflow
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/ot981a1/
+### u/dreamzzftw — Addition or operator report
+
+- Score at capture: 1
+- Comment: Is there any way of keeping configs between profiles on sync? I find that having to make sure the config of 9 different profiles can be tedious. The only thing I don’t want synced is the model used for each profile
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/ottzms5/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 1
+- Comment: I think you can probably prompt your hermes to map the locations lines in each config and create a script that can change it or keep in sync.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/otu0tbz/
+### u/dreamzzftw — Addition or operator report
+
+- Score at capture: 1
+- Comment: Great idea, thank you
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/otucsup/
+### u/errantekarmico — Addition or operator report
+
+- Score at capture: 1
+- Comment: You can create symlinks to the main configuration files
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucmvi8/multiagent_profiles_megathread_hermes_agent_june/otua2sg/

--- a/references/reddit-comment-notes-qwen3.6-27b-community-variants-2026-07.md
+++ b/references/reddit-comment-notes-qwen3.6-27b-community-variants-2026-07.md
@@ -1,0 +1,123 @@
+# Reddit Comment Notes — Qwen3.6-27B Community Variants — The Definitive Guide for Limited Hardware
+
+Original thread: https://www.reddit.com/r/hermesagent/comments/1tn4lye/qwen3627b_community_variants_the_definitive_guide/
+
+Captured for provenance during the July 16, 2026 migration. Classification is editorial triage, not independent verification. Promotional, reputational, pricing, benchmark, version, and availability claims require primary-source checks before entering the canonical guide.
+
+Praise, jokes, GIFs, removed/deleted bodies, bot reminders, and other non-substantive comments are intentionally omitted.
+
+### u/Witty_Mycologist_995 — Needs verification
+
+- Score at capture: 3
+- Comment summary: Unverified user allegation concerning the publisher and model quality; accusation wording omitted pending primary-source verification.
+- Source: https://www.reddit.com/r/hermesagent/comments/1tn4lye/qwen3627b_community_variants_the_definitive_guide/onstany/
+### u/camelos1 — Addition or operator report
+
+- Score at capture: 1
+- Comment: what are you talking about?
+- Source: https://www.reddit.com/r/hermesagent/comments/1tn4lye/qwen3627b_community_variants_the_definitive_guide/oqmn9hn/
+### u/Witty_Mycologist_995 — Addition or operator report
+
+- Score at capture: 1
+- Comment: Search him up
+- Source: https://www.reddit.com/r/hermesagent/comments/1tn4lye/qwen3627b_community_variants_the_definitive_guide/oqnb35l/
+### u/shahonseven — Addition or operator report
+
+- Score at capture: 2
+- Comment: Which one is good for mac studio m1 max 64gb ram?
+- Source: https://www.reddit.com/r/hermesagent/comments/1tn4lye/qwen3627b_community_variants_the_definitive_guide/onrxs2c/
+### u/Jonathan_Rivera — Needs verification
+
+- Score at capture: 4
+- Comment: 🥇 DavidAU Heretic NEO-CODE at Q6_K (~21 GB file, ~24 GB with context) - This is the best Qwen3.6-27B variant, period. Published benchmarks show it beats the base model. You have the headroom for Q6_K (virtually lossless) and can still run 32K+ context. Get the GGUF from DavidAU/Qwen3.6-27B-Heretic-Uncensored-FINETUNE-NEO-CODE-Di-IMatrix-MAX-GGUF. Run with Metal backend (llama.cpp or LM Studio). 🥈 rico03 Opus 4.6 Distilled at Q6_K if reasoning is your priority - the Jackrong recipe + Opus 4.6 reasoning traces. You have room for Q8_0 (26.6 GB) if you want maximum reasoning quality. 🥉 HauhauCS Aggressive at Q6_K if you want the exact base model behavior but uncensored (0/465 refusals). On MTP: The MTPLX MLX-native runtime (63 tok/s) is optimized for M-series MacBooks. Your M1 Max has much more memory bandwidth than a MacBook but the same architecture - MTPLX might work but the post lists it for MacBooks specifically. Standard Metal backend should get you 20-30 tok/s at Q6_K which is perfectly usable. If you try MTP, the overhead is only ~1 GB on the dense 27B.
+- Source: https://www.reddit.com/r/hermesagent/comments/1tn4lye/qwen3627b_community_variants_the_definitive_guide/ont9hv1/
+### u/Acclaim1H — Addition or operator report
+
+- Score at capture: 1
+- Comment: Why not DavidAU Heretic NEO-CODE at Q8\_0? Asking genuinely as that's the model variant I went with on my dual 3090 setup -- just as of today after finding this post, haha. Prior to today's swap, I've had success running vanilla Qwen3.6-27B also at Q8\_0 with 131072 context, so have the heretic variant setup the same way. Anyway, thanks for the crucial round-up! Very cool post. EDIT: Also, compared to 100% GPU solutions, aren't the mac studio's going to be quite slow? I'm aware of their proprietary memory bridge, but it's still ram in the end.
+- Source: https://www.reddit.com/r/hermesagent/comments/1tn4lye/qwen3627b_community_variants_the_definitive_guide/oxnvtak/
+### u/Large-Plant2870 — Addition or operator report
+
+- Score at capture: 2
+- Comment: Would be interesting to consider igpus e.g. AMD Radeon 890
+- Source: https://www.reddit.com/r/hermesagent/comments/1tn4lye/qwen3627b_community_variants_the_definitive_guide/onsi0sc/
+### u/HolyBeeDub — Needs verification
+
+- Score at capture: 2
+- Comment: I wish to deploy more powerful open models locally, but after looking up the graphic card and memory prices, it is equivalent of 3 years of Claude subscription. Who knows what the world is going to be in 3 years? Might as well stick with smaller models for now.
+- Source: https://www.reddit.com/r/hermesagent/comments/1tn4lye/qwen3627b_community_variants_the_definitive_guide/onteixg/
+### u/acceleroto — Addition or operator report
+
+- Score at capture: 2
+- Comment: Outstanding post. FWIW, the original Froggeric 27b MTP Q6\_K at 160k context with the PR llama.cpp build has been great for my 1x 16GB 5060Ti + 2x 12GB 3060 setup with Hermes & OpenCode. (I have room for a little more context too.)
+- Source: https://www.reddit.com/r/hermesagent/comments/1tn4lye/qwen3627b_community_variants_the_definitive_guide/oohu05j/
+### u/acceleroto — Addition or operator report
+
+- Score at capture: 1
+- Comment: Wait, Qwopus3.6-27B-v2-MTP is out. Firing it up now (Q6\_K fits w/192k context & q8 cache in my 40GB 3xGPU contraption). https://preview.redd.it/kgh05vt8c04h1.png?width=84&format=png&auto=webp&s=ee4ea392f4c2bf7f43b4ca228df60eee6cafffdd
+- Source: https://www.reddit.com/r/hermesagent/comments/1tn4lye/qwen3627b_community_variants_the_definitive_guide/ooifve7/
+### u/Unixwzrd — Addition or operator report
+
+- Score at capture: 1
+- Comment: `n_ctx` is also a big factor. Using smaller context will improve performance, but you lose “short-term” memory or use for managing large prompts. Don’t expect 256k n_ctx to run fast. KV caching can also help, but does not work with MTP. `ngram` caching and storing KV cache on SSD will allow for switching out the cache between different prompts/contexts. This will also work with mmproj(vision).
+- Source: https://www.reddit.com/r/hermesagent/comments/1tn4lye/qwen3627b_community_variants_the_definitive_guide/ontvaz6/
+### u/Sjsamdrake — Needs verification
+
+- Score at capture: 1
+- Comment: Thanks for this. FYI here is a little data for Qwen 3.6 on Strix Halo (128GB Framework Desktop): * Qwen\_Qwen3.6-35B-A3B-GGUF-Q8\_0: 51 tps * Qwen3.6-35B-A3B-GGUF-BF16: 10 tps * Qwen3.6-27B-GGUF: 12 tps This is on a simple little test run in Lemonade. Lemonade was stopped and started before each test. *hi how are you today?* *how many atoms are on the head of a pin?* Certainly not a great benchmark but the numbers match what I see in every day use. Given the speed difference the Q8\_0 is my daily driver at the moment.
+- Source: https://www.reddit.com/r/hermesagent/comments/1tn4lye/qwen3627b_community_variants_the_definitive_guide/onu6odn/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 2
+- Comment: Great! We will roll up all the comments from this post and add it to the wiki. Thanks
+- Source: https://www.reddit.com/r/hermesagent/comments/1tn4lye/qwen3627b_community_variants_the_definitive_guide/onu92ua/
+### u/Infinite_Copy_8651 — Needs verification
+
+- Score at capture: 1
+- Comment: \*\*52 tok/s on unsloth / Qwen3.6-27B-MTP-GGUF — pure CPU (i5), llama.cpp + speculative decoding + KV cache q4\_0\*\* \--- \*\*Hardware & config\*\* \- Model: \`unsloth / Qwen3.6-27B-MTP-GGUF\` \- Backend: llama.cpp (llama server) \- Context: 131072 | KV Cache: q4\_0 (K + V) \- Speculative decoding: \`draft-mtp\` | \`--spec-draft-n-max 2\` \- Sampling: temp 1.0 · top-p 0.95 · top-k 20 · presence penalty 1.5 \- RAM at test time: 8.5 / 10 GiB (85%) | Average load: 0.22 \--- \*\*Launch command\*\* nohup llama-server \\ \-m /root/models/Qwen3.6-27B-Q4\_K\_M.gguf \\ \--port 8080 --host [0.0.0.0](http://0.0.0.0) \\ \-ngl 99 \\ \--ctx-size 131072 \\ \--cache-type-k q4\_0 \\ \--cache-type-v q4\_0 \\ \--temp 1.0 --top-p 0.95 --top-k 20 \\ \--min-p 0.0 --presence-penalty 1.5 \\ \--spec-type draft-mtp --spec-draft-n-max 2 \--- \*\*Benchmark results\*\* | Test | Prompt tok | Generated tok | Time | Speed | |---|---|---|---|---| | Warm-up | — | 50 | 3.77s | 13.3 tok/s | | Short prompt | 13 | 300 | 6.45s | \*\*46.5 tok/s\*\* | | Long cold ctx | 809 | 100 | 2.07s | 48.3 tok/s | | Long cached ctx | 809 | 300 | 5.75s | \*\*52.2 tok/s\*\* | \*\*Session comparison (\~2h apart, same config)\*\* | Metric | Before | After | Delta | |---|---|---|---| | Short generation | 43.0 tok/s | 46.5 tok/s | +8% | | Cached generation | 51.8 tok/s | 52.2 tok/s | stable | | RAM | 94% | 85% | −9 pp | \---
+- Source: https://www.reddit.com/r/hermesagent/comments/1tn4lye/qwen3627b_community_variants_the_definitive_guide/onv5q1o/
+### u/Jonathan_Rivera — Needs verification
+
+- Score at capture: 2
+- Comment: translated to American lol ;-) # Hardware & Config * Model: `Qwen3.6-27B-Q4_K_M.gguf` * Backend: llama.cpp (llama server) * Context: `131072` | KV Cache: `q4_0` (K + V) * Speculative decoding: `draft-mtp` | `--spec-draft-n-max 2` * Sampling: temp `1.0` · top-p `0.95` · top-k `20` · presence penalty `1.5` * RAM at test time: `8.5 / 10 GiB (85%)` | Average load: `0.22` &#8203; nohup llama-server \ -m /root/models/Qwen3.6-27B-Q4_K_M.gguf \ --port 8080 --host 0.0.0.0 \ -ngl 99 \ --ctx-size 131072 \ --cache-type-k q4_0 \ --cache-type-v q4_0 \ --temp 1.0 --top-p 0.95 --top-k 20 \ --min-p 0.0 --presence-penalty 1.5 \ --spec-type draft-mtp --spec-draft-n-max 2 nohup llama-server \ -m /root/models/Qwen3.6-27B-Q4_K_M.gguf \ --port 8080 --host 0.0.0.0 \ -ngl 99 \ --ctx-size 131072 \ --cache-type-k q4_0 \ --cache-type-v q4_0 \ --temp 1.0 --top-p 0.95 --top-k 20 \ --min-p 0.0 --presence-penalty 1.5 \ --spec-type draft-mtp --spec-draft-n-max 2 # Benchmark Results |Test|Prompt Tokens|Generated Tokens|Time|Speed| |:-|:-|:-|:-|:-| |Warm-up|—|50|3.77s|13.3 tok/s| |Short prompt|13|300|6.45s|**46.5 tok/s**| |Long cold context|809|100|2.07s|48.3 tok/s| |Long cached context|809|300|5.75s|**52.2 tok/s**Benchmark ResultsTest Prompt Tokens Generated Tokens Time SpeedWarm-up — 50 3.77s 13.3 tok/sShort prompt 13 300 6.45s 46.5 tok/sLong cold context 809 100 2.07s 48.3 tok/sLong cached context 809 300 5.75s 52.2 tok/s| |Metric|Before|After|Delta| |:-|:-|:-|:-| |Short generation|43.0 tok/s|46.5 tok/s|\+8%| |Cached generation|51.8 tok/s|52.2 tok/s|Stable| |RAM usage|94%|85%|−9 ppMetric Before After DeltaShort generation 43.0 tok/s 46.5 tok/s +8%Cached generation 51.8 tok/s 52.2 tok/s StableRAM usage 94% 85% −9 pp|
+- Source: https://www.reddit.com/r/hermesagent/comments/1tn4lye/qwen3627b_community_variants_the_definitive_guide/onv7ofl/
+### u/fucilator_3000 — Addition or operator report
+
+- Score at capture: 1
+- Comment: There is something good for everyday task (simple) with M1 Pro 16GB?
+- Source: https://www.reddit.com/r/hermesagent/comments/1tn4lye/qwen3627b_community_variants_the_definitive_guide/onx8jre/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 3
+- Comment: Some people have had success with Qwen 3.5 9B. I would tell you no. You will be more frustrated trying to get it to work. With m1 16gb its almost always advisable to get on a plan or somewhere you can get cheap credits. If you have chat gpt plus, use oauth to codex gpt 5.4mini or deepseek api or free to low cost models on open router. Rotating between free keys and low cost models you should be able to come in under $20 a month.
+- Source: https://www.reddit.com/r/hermesagent/comments/1tn4lye/qwen3627b_community_variants_the_definitive_guide/onx94fk/
+### u/Material-Mention6696 — Addition or operator report
+
+- Score at capture: 1
+- Comment: amazing post! i have a 7900xtx 24gb i want to run the most capable model for hermes, which one should i use with my setup? rico, david, hauhau, jackrong I don't know, just want hermes to be as error free as possible
+- Source: https://www.reddit.com/r/hermesagent/comments/1tn4lye/qwen3627b_community_variants_the_definitive_guide/onz0rpo/
+### u/chameleontuning — Addition or operator report
+
+- Score at capture: 1
+- Comment: qwen3.6 27B Q4\_K\_M David AU
+- Source: https://www.reddit.com/r/hermesagent/comments/1tn4lye/qwen3627b_community_variants_the_definitive_guide/orqeldx/
+### u/TheWorstLaidPlans — Addition or operator report
+
+- Score at capture: 1
+- Comment: Thoughts on M3 MAX 128GB? I'd like to run David's, but MLX is needed, and Id like MTP. I've been running omlx and ollama.
+- Source: https://www.reddit.com/r/hermesagent/comments/1tn4lye/qwen3627b_community_variants_the_definitive_guide/oo5lo5d/
+### u/TheWorstLaidPlans — Addition or operator report
+
+- Score at capture: 1
+- Comment: Absolutely great post btw.
+- Source: https://www.reddit.com/r/hermesagent/comments/1tn4lye/qwen3627b_community_variants_the_definitive_guide/oo5lsmn/
+### u/Careful_cat99 — Addition or operator report
+
+- Score at capture: 1
+- Comment: Post absolument génial Perso j'utilise Huihui-Qwen3.6-35B-A3B-abliterated en Q4_k j'en suis ravie mais je vais tester la Q6 et lancé une version 27b en parallèle pour voir les résultats
+- Source: https://www.reddit.com/r/hermesagent/comments/1tn4lye/qwen3627b_community_variants_the_definitive_guide/oo8gvfb/
+### u/henryaiart — Addition or operator report
+
+- Score at capture: 1
+- Comment: thanks for sharing! really good work!
+- Source: https://www.reddit.com/r/hermesagent/comments/1tn4lye/qwen3627b_community_variants_the_definitive_guide/oq2lf59/

--- a/references/reddit-comment-notes-qwen3.6-35b-a3b-community-variants-2026-07.md
+++ b/references/reddit-comment-notes-qwen3.6-35b-a3b-community-variants-2026-07.md
@@ -1,0 +1,263 @@
+# Reddit Comment Notes — Qwen3.6-35B-A3B Community Variants — The Definitive Guide for Limited Local Hardware
+
+Original thread: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/
+
+Captured for provenance during the July 16, 2026 migration. Classification is editorial triage, not independent verification. Promotional, reputational, pricing, benchmark, version, and availability claims require primary-source checks before entering the canonical guide.
+
+Praise, jokes, GIFs, removed/deleted bodies, bot reminders, and other non-substantive comments are intentionally omitted.
+
+### u/Jonathan_Rivera — Correction or contradiction
+
+- Score at capture: 4
+- Comment: Correction - MTP llama has been in the branch for about a week.
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onplfw1/
+### u/Witty_Mycologist_995 — Needs verification
+
+- Score at capture: 8
+- Comment summary: Unverified user allegation concerning the publisher; accusation wording omitted pending primary-source verification.
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onoflr5/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 7
+- Comment: I get it but it's out there and it's just aggregated for the informative post. Your more than welcome to post the story of what happened in this thread. I'm sure most people don't know.
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onoggs3/
+### u/Appropriate_Car_5599 — Addition or operator report
+
+- Score at capture: 3
+- Comment: Why? Can you please elaborate more on that? really interesting 🤔
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onoml76/
+### u/FaceDeer — Addition or operator report
+
+- Score at capture: 2
+- Comment summary: A user linked to a separate Reddit allegation concerning attribution and licensing. The allegation is unverified here; consult primary repository history and license evidence before drawing conclusions.
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/ononeue/
+### u/Appropriate_Car_5599 — Addition or operator report
+
+- Score at capture: 3
+- Comment summary: Non-substantive reaction to the unverified allegation; verdict wording omitted.
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onooy8c/
+### u/MidnightSkyFlower — Addition or operator report
+
+- Score at capture: 1
+- Comment summary: A different user disputed the allegation. Neither side is adjudicated in this repository.
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onuq58j/
+### u/robberviet — Addition or operator report
+
+- Score at capture: 0
+- Comment: Agree, we must have standard.
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onwx283/
+### u/smolpotat0_x — Needs verification
+
+- Score at capture: 8
+- Comment: MTP got merged to llama.cpp few days ago, i’m getting a boost from 45ish tok/sec to 75-90 tok/s on the unsloth IQ4_XS quant with 128k context
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onoftqa/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 2
+- Comment: What's your MTP max draft set to?
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onog42c/
+### u/smolpotat0_x — Addition or operator report
+
+- Score at capture: 1
+- Comment: max draft =2. im sure it can be improved and i don't still quite understand all the flags but this is what my llama-swap config i went back and forth with hermes. gpu: 4070 ti super (16gb) + 2080ti (11gb) Qwen3.6-35B-A3B-MTP-UD-IQ4\_XS \-ngl 99 \--tensor-split 19,8 \-sm layer \-fa on \-c 131072 \-np 1 \--cache-type-k q4\_0 \--cache-type-v q4\_0 \-b 2048 \-ub 2048 \--jinja \--reasoning on \--reasoning-budget 4096 \--spec-type draft-mtp \--spec-draft-n-max 2 \-t 8 ttl: 1800
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onolkx6/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 2
+- Comment: Mine has been 2 as well for all models.
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onor7z8/
+### u/smolpotat0_x — Addition or operator report
+
+- Score at capture: 1
+- Comment: curious what your flags are, what hardware you rocking?
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onov9sw/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 2
+- Comment: LM studio right this second. I tried llama but I just didn't like it, I like to visualize how fast everything is going. Primary 5090 32gb with a 5070ti 16gb in a test bench. May use it to run a second model for compression or aux tasks or image generation with comfy UI. Testing out different uncensored variants of 35b. Right this second huihui-qwen3.6-35b-a3b-claude-4.7-opus-abliterated-mtp is loaded. Context 128k / GPU offload max / CPU thread pool Max/ Evaluation batch size 4096 Concurrent or parallel sessions 2 / Unified KV cache off / mmap on MTP max 2 / Q4 KV cache / temp 0.6 / context overflow - rolling / Top K 20, repeat 1, Presence 1.5, Top P 0.8, min p 0 / think on / Reasoning section parsing on &lt;think&gt; &lt;/think&gt;
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onowpot/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 6
+- Comment: https://preview.redd.it/m0ik2ixes53h1.png?width=1189&format=png&auto=webp&s=18d500c34e35043a1591bf98a455980aecf7994b Incase anyone is curious, all the research for the two megathreads, formatting, scraping etc. on the deepseek api. lol..............
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onojngq/
+### u/FaceDeer — Addition or operator report
+
+- Score at capture: 4
+- Comment: The main issue I'm having with running Hermes with a local LLM is that it keeps getting caught in a loop calling the same tool calls over and over. I've messed around with temperature and repetition penalties and whatnot to no avail, at this point I'm suspecting that it's a result of assumptions about timeouts and lack of concurrency causing the same prompt to get tried repeatedly. Is there a straightforward way to configure Hermes to tell it "look, just wait as long as you need for responses to come back, I'm not in a hurry"? Including stuff like the chat-titling call, context compression, and so forth? Or do I need to find all the timeouts and set them unreasonably long?
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onoo82h/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 3
+- Comment: What model and hardware?
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onooe1m/
+### u/FaceDeer — Addition or operator report
+
+- Score at capture: 2
+- Comment: Model is Qwen 3.6 35B A3B Q4_K_M on LM Studio. The hardware is NVIDIA RTX A4000 with 16GB of VRAM, 64GB of system RAM. My goal isn't anything super fancy, this is a hobby agent I'm planning on using mainly as a "personal secretary" that I can DM on Discord to have it track todos and other personal information for me. So it's fine if it takes a while to do anything. I had put working on this on the back burner since there's been a lot of talk about MTP support coming to speed things up, I was going to have another go at getting things working smoothly when that was available and well tested, but since this thread popped up and I'm using Qwen3.6-35B I figured I'd see if anyone had personal experience with this. I've tried chatting with various AIs like Gemini about this, but this is such a new and flakey software stack that it was getting a lot of jumbled advice to try to comb through. :)
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onopta3/
+### u/mike7seven — Addition or operator report
+
+- Score at capture: 3
+- Comment: I assume you have thinking enabled. There’s actually two settings for the model that are on the model card that need to be set to false. Preserve_thinking and Enable_thinking. This will turn off thinking entirely. There’s a known defect in which a partial thinking tag gets caught in a response that trips up the tool calls then the model goes into a errored out response.
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onowz14/
+### u/FaceDeer — Addition or operator report
+
+- Score at capture: 3
+- Comment: Ah, I haven't tried disabling thinking entirely. I'll give that a go and see how it works.
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onozc7q/
+### u/Yeelyy — Addition or operator report
+
+- Score at capture: 2
+- Comment: Wait are you saying that its best for Hermes use to turn off thinking entirely? Seems counterproductive for intelligence?
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/oosah5v/
+### u/mike7seven — Addition or operator report
+
+- Score at capture: 2
+- Comment: Qwen 3.6 has a deep thinking problem. That’s one of the reasons that the Qwen Opus distilled models are better if you want thinking. I’ve been using with thinking disabled and it’s been working well for me. Having thinking/reasoning enabled doesn’t always mean your output is going to be better.
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/ootqi2e/
+### u/Yeelyy — Addition or operator report
+
+- Score at capture: 2
+- Comment: Highly interesting. Thank you, im gonna try it out
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/oouackw/
+### u/mike7seven — Addition or operator report
+
+- Score at capture: 1
+- Comment: 👌🏼let us know the results
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/oov1csi/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 1
+- Comment: I have the same model and setup. Use the unsloth version which is tuned a little better for tool use. Might as well go down to Q4KS. Temp 0.6. If tools keep failing look under the workshop flair and find me skill audit. You may want to connect to a cloud api to rewrite the skills to ensure they are efficient. I think the time out may be here - HERMES\_API\_TIMEOUT=60 in ~/.hermes/.env
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onou5s3/
+### u/FaceDeer — Addition or operator report
+
+- Score at capture: 1
+- Comment: Okay, thanks. I'll try out the Unsloth model, I've just been using the default "lmstudio community" version since I figured that was most likely to work smoothly. The agent doesn't seem to have trouble actually calling tools, the problem comes somewhere after the tool call is made. The other day I woke up to it reminding me about an appointment 60 times in a row because it got caught in a loop setting the cron job. :)
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onow0wn/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 1
+- Comment: Feel free to message me later about it. Like i said I have everything the same except for the gpu.
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onowyc6/
+### u/FaceDeer — Addition or operator report
+
+- Score at capture: 1
+- Comment: Will do. It could just be some weird little glitch that will go away as soon as some part of my setup auto-updates to a slightly newer version. I picked Hermes over OpenClaw to play with because all indications were that it was much more stable, but all software has its weird idiosyncrasies sometimes and LLMs are fertile ground for magnifying that sort of thing.
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onoyyzd/
+### u/Jonathan_Rivera — Correction or contradiction
+
+- Score at capture: 1
+- Comment: Skills should have exact tools used with paths etc for maximum success. If Hermes can see the next rock before jumping your good. Issues come when the skill says do this and that with no path or tool specified and it’s trying to think on the fly.
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onozgef/
+### u/FaceDeer — Addition or operator report
+
+- Score at capture: 1
+- Comment: In my case I'm seeing issues with setting simple cron job reminders, which I assume are a pretty well-understood and straightforward skill.
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onp3hgp/
+### u/Jonathan_Rivera — Correction or contradiction
+
+- Score at capture: 0
+- Comment: I'm going to copy paste my agents response since it aligns with my first thought. Context: FaceDeer runs Qwen3.6-35B-A3B Q4\_K\_M on LM Studio (RTX A4000 16GB). He's having trouble with Hermes cron job reminders. Johnathan (you) advised switching to the Unsloth quant, Q4K\_S, temp 0.6, and checking the skill audit workshop post. Likely reasons his Hermes cron reminders are failing: 1. Model + Quantization mismatch for tool calling. Qwen3.6-35B-A3B is an MoE. The default "lmstudio community" Q4\_K\_M quant isn't tuned for Hermes' tool-calling patterns. Johnathan's advice to switch to the Unsloth version at Q4K\_S is the first fix — Unsloth tunes their quants specifically to preserve instruction-following and function-calling performance, which Hermes cron depends on. 2. Tool-looping pattern. FaceDeer's original complaint was the agent calling the same tools repeatedly — a classic sign of the model getting confused about tool results, or repetition penalty issues with MoE quants. Cron jobs are self-contained agent sessions; if the base model loops on tool calls in chat, it'll loop on cron too. 3. Skill specificity. Johnathan's point about skills needing "exact tools used with paths" is key. Hermes cron jobs rely on skills being self-contained and unambiguous. If FaceDeer's cron skill says "remind me at 3pm" without specifying the exact tool and format, a weaker local quant will hallucinate the approach rather than following a clear path. 4. VRAM headroom. Qwen3.6-35B-A3B at Q4\_K\_M with 16GB VRAM leaves very little headroom for context, especially with tool-call overhead. Running out of VRAM mid-cron-execution (silent OOM) would cause it to fail silently. Johnathan's suggestion of Q4K\_S (slightly smaller) plus the Unsloth tuning helps here. 5. Context window fragmentation. The A3B MoE routing at Q4\_K\_M can degrade on structured tool-use prompts — the shared experts handle routing logic, but heavy quantization on them means the model loses track of the c … [excerpt intentionally limited to avoid republishing a large script or identity-specific configuration; use the source link for the full public comment]
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onp50h9/
+### u/Niehaus_1301 — Correction or contradiction
+
+- Score at capture: 1
+- Comment: I'm having the same issue running Qwen3.6-27B-MTP-GGUF (Unsloth) at q4\_K\_XL, q8\_0 KV. --ctx-size 393216 # (384K shared via --kv-unified) --cache-type-k q8_0 --cache-type-v q8_0 --flash-attn on --ubatch-size 512 --split-mode layer # pipeline parallelism across 2 R9700s --no-mmap --parallel 2 --kv-unified --cont-batching --cache-ram 32768 --slot-prompt-similarity 0.30 --temp 0.6 --top-p 0.95 --top-k 20 --min-p 0.0 --presence-penalty 1.5 --repeat-penalty 1.0 --dry-multiplier 0.8 --dry-allowed-length 10 --reasoning-budget 6144 --reasoning-budget-message "OK, I've thought enough. Let me answer." --chat-template-kwargs '{"enable_thinking": true, "preserve_thinking": true}' --reasoning-format deepseek --spec-type draft-mtp --spec-draft-n-max 2 --chat-template-file /chat-template.jinja # froggeric Qwen3.5/3.6 fixed
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onquhe5/
+### u/Economy-Flight-5646 — Addition or operator report
+
+- Score at capture: 3
+- Comment: thanks my brother, very usefull
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onqbedi/
+### u/NewDistribution549 — Addition or operator report
+
+- Score at capture: 2
+- Comment: So I should use mudler [Qwen3.6-35B-A3B-APEX-MTP-I-Mini](https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF/blob/main/Qwen3.6-35B-A3B-APEX-MTP-I-Mini.gguf) 14.3gb if I have RX 7600 XT 16gb vram and 32gb ddr4? I'm mostly using it for hermes so I need good tool calling and maybe coding using 64k context limit. if anybody has any recommendations or tips I'd be grateful I'm still a beginner
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onowotj/
+### u/Hermes_helper — Needs verification
+
+- Score at capture: 0
+- Comment: The mudler APEX-MTP-I-Mini at 13.3 GB is a solid choice for your RX 7600 XT. You've got 16GB VRAM and 32GB system RAM, so the math works: \~15 GB VRAM total with 32K context leaves a 1GB breathing room. The APEX quantization is specifically tuned for MoE routing — it compresses routed experts harder while keeping shared experts high precision, so you get better quality-per-byte than standard K-quants at the same file size. A few things to consider though: MTP overhead — MTP adds roughly 1GB on top. The I-Mini quant sits at 13.3 GB file size, so you're looking at\~15-16 GB total with moderate context. That fits but leaves very little headroom. If you start pushing to 64K context you'll spill into system RAM via offloading, which with DDR4 32GB will be noticeably slower. Consider starting at 32K context, and if you need 64K for coding, test whether the speed tradeoff is acceptable for your workflow. For tool calling specifically — The mudler APEX-MTP variants use base Qwen3.6 (not reasoning-distilled). That's actually a plus for Hermes Agent tool calling. Reasoning-distilled variants emit long thinking... response blocks that can trip up tool call parsing in some setups. The base model's shorter, more direct responses tend to play nicer with agent frameworks. If you do want reasoning + MTP, mudler also publishes the Opus 4.7 distill in APEX-MTP format — that variant is 21.7K downloads with good feedback. Alternative at your VRAM tier — lordx64 Opus 4.7 IQ3\_M (14.4 GB, \~17 GB total) is a strong alternative if you're willing to skip MTP and do some offloading for long contexts. The reasoning traces from Claude Opus 4.7 are the cleanest available. You can always add MTP later via mudler's APEX wrapper on top if you want both. Bottom line — Your pick (mudler APEX-MTP-I-Mini) is the right first try for your hardware. If you find it slow at 64K or the MTP doesn't improve tokens/sec on AMD (worth validating empirically), drop down to the non-MTP APEX Compact at … [excerpt intentionally limited to avoid republishing a large script or identity-specific configuration; use the source link for the full public comment]
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onoyb6p/
+### u/NewDistribution549 — Addition or operator report
+
+- Score at capture: 2
+- Comment: What about Devstral-Small-2-24B-Instruct-2512 IQ4\_XS 14.54GB or UD Q3\_K\_XL 13.61GB? is it good for hermes framework?
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onpfopg/
+### u/Hermes_helper — Needs verification
+
+- Score at capture: 1
+- Comment: Devstral-Small-2-24B is a Mistral Small 3 derivative with community fine-tunes. It can run as a Hermes provider via Ollama or LM Studio — same as any GGUF you point at it.Two things to watch:1. \*\*Qwen3.6-35B-A3B at Q4\_K\_M (\~22GB) will outperform it on reasoning benchmarks.\*\* The MoE architecture gives you 35B effective parameters at a \~22B memory footprint. If you can fit \~22GB, that's the better pick for complex tasks like multi-step tool use, debugging, and code generation. The GGUF quant from unsloth or bartowski on HuggingFace works directly.2. \*\*Devstral's context window varies by quant source.\*\* The base Mistral Small 3 supports 32K, but some community GGUFs cap at 8K or 16K. Check the model card. For Hermes, 32K+ is strongly recommended — the system prompt and tool definitions eat \~3-5K before you even start.If you're capped at \~14GB VRAM with no offloading, Devstral at IQ4\_XS (14.5GB) is a reasonable choice. If you have 16GB+ unified memory (Apple Silicon), Qwen3.6-35B-A3B at Q4\_K\_M with some offloading is the better fit.Both will work — Hermes talks to them the same way. The difference is in reasoning depth and how many tools/responses they can handle before context churn.
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onpnmmn/
+### u/ironbreaker999 — Addition or operator report
+
+- Score at capture: 2
+- Comment: Lmao vram impaired. Love it.
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onp83b2/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 3
+- Comment: lol. Tomorrow is the 27B Thread.
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onp8hpg/
+### u/No_Taste_4102 — Needs verification
+
+- Score at capture: 2
+- Comment: Just downloaded qwopus3.6-35b-a3b-v1-apex-mtp (the model that is Compact I version and about 17 or 18gb, can't really remember right now, my workstation is far enough to check.) And god, it has really high speed, about 90-100tok/sec on my setup on top of LM studio beta. I'm at 4070 12gb + 5060ti 16gb. I managed to pull out a 120k context with default bf16 kv quant. I believe i could get 200k if i lower the kv quant to q4. Gonna run some tests later. Didn't really test it on the coding purposes yet, but it seems to maintain high agentic potential. I use vs code cline, and it parsed a massive project documentation really fast
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onqe9rm/
+### u/UntimelyAlchemist — Correction or contradiction
+
+- Score at capture: 2
+- Comment: My picks are Unsloth for most use cases, and HauhauCS when I need an uncensored model. For uncensored, HauhauCS is the king. I wish he'd open source his workflow, but the results can't be argued with. For general use, I picked Unsloth as they have a good reputation and document their releases nicely. I'm interested in trying the Byteshape releases though. Oh, I'm also using the fixed chat template that's available on HuggingFace.
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onuud1e/
+### u/Jonathan_Rivera — Needs verification
+
+- Score at capture: 2
+- Comment: Same. I hit walls with heritic but Hauhau worked fine. I created a coach still for business advice and the unsloth model refused to help due to identity rules. Uncensored has a lot of uses other than NSFW including cyber security.
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onuuuhi/
+### u/Toastti — Addition or operator report
+
+- Score at capture: 1
+- Comment: MTP has been in the main branch of llama.cpp for about a week now
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onpg1zi/
+### u/ElectricalAngle1611 — Addition or operator report
+
+- Score at capture: 1
+- Comment: this post is terrible and slop and wrong and has so many logical parts that just don’t make any sense
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onr0sgl/
+### u/blablsblabla42424242 — Addition or operator report
+
+- Score at capture: 1
+- Comment: Excellent analysis and comparison, thank you!
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onsdw5e/
+### u/Large-Plant2870 — Addition or operator report
+
+- Score at capture: 1
+- Comment: Thank you. Great Summary. Would be interesting to consider igpus also e.g. AMD Radeon 890
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/onsjoef/
+### u/Ok-Project-303 — Addition or operator report
+
+- Score at capture: 1
+- Comment: My tests on Strix Halo 128 https://preview.redd.it/iktokdqxnk3h1.png?width=1155&format=png&auto=webp&s=0f1da1457015d8e3c44cb460adf646f9b5e8fe3e |LLM|Quant|Context|tps| |:-|:-|:-|:-| |qwen3.6-27b-uncensored-heretic-v2|bf16|120000|3| |qwen3.6-27b-mtp|bf16|120000|5| |qwen3.6-27b-uncensored-heretic-v2-native-mtp-preserved|bf16|120000|6| |unsloth/qwen3.6-27b|Q8|250000|7| |qwen3.6-35b-a3b-mtp|bf16|250000|11| |nvidia/nemotron-3-super|Q4|1000000|13| |qwen3.6-27b-mtp|Q4|250000|22| |qwen3.6-27b-uncensored-heretic-v2-native-mtp-preserved|Q4|250000|24| |qwen3.6-35b-a3b-uncensored-hauhaucs-aggressive|Q8|250000|37| |qwen3-coder-next|Q8|250000|40| |openai/gpt-oss-120b|MXFP4|100000|46| |holo3-35b-a3b|Q8|200000|50| |qwen/qwen3.6-35b-a3b|Q8|250000|50| |qwen/qwen3-coder-next|Q4|250000|54| |zai-org/glm-4.7-flash|Q4|200000|54| |qwen3.6-35b-a3b-mtp|Q8|250000|55| |gpt-oss-20b-uncensored-hauhaucs-aggressive|MXFP4|130000|65| |qwen3.6-35b-a3b-mtp|Q4|250000|70| |qwen3.6-35b-a3b-uncensored-heretic-native-mtp-preserved|Q4|250000|77| |qwen/qwen3-coder-30b|Q4|250000|80| |llama-3.2-1b-instruct|Q8|131072|137| |qwen2.5-0.5b-instruct|Q8|32700|242|
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/oo2psvd/
+### u/Xephen20 — Addition or operator report
+
+- Score at capture: 1
+- Comment: What about mlx and mlx quants?
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/opbpn9x/
+### u/Jonathan_Rivera — Addition or operator report
+
+- Score at capture: 1
+- Comment: I think that's going to have to be a separate post.
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/opbsa74/
+### u/shab2310 — Addition or operator report
+
+- Score at capture: 1
+- Comment: Hey, I'm a bit confused about the context window stuff for this quopus model variant. I thought it was supposed to handle way more tokens than 32k, like up to 256k. Is there a reason why yarn or rope scaling is even a thing here then? I'm trying to get my head around the limitations and capabilities. Any insights would be super helpful!
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/oqrzkg7/
+### u/shab2310 — Addition or operator report
+
+- Score at capture: 1
+- Comment: Did the SWE bench scores ever get published for qwopus?
+- Source: https://www.reddit.com/r/hermesagent/comments/1tmp2qy/qwen3635ba3b_community_variants_the_definitive/oqrzorv/

--- a/references/reddit-comment-notes-vps-deployment-2026-06.md
+++ b/references/reddit-comment-notes-vps-deployment-2026-06.md
@@ -1,0 +1,23 @@
+# Reddit Comment Notes — VPS & Deployment Megathread — Hermes Agent (June 2026)
+
+Original thread: https://www.reddit.com/r/hermesagent/comments/1ucke01/vps_deployment_megathread_hermes_agent_june_2026/
+
+Captured for provenance during the July 16, 2026 migration. Classification is editorial triage, not independent verification. Promotional, reputational, pricing, benchmark, version, and availability claims require primary-source checks before entering the canonical guide.
+
+Praise, jokes, GIFs, removed/deleted bodies, bot reminders, and other non-substantive comments are intentionally omitted.
+
+### u/JaySomMusic — Addition or operator report
+
+- Score at capture: 3
+- Comment: Another self hosted/vps option is taOS https://github.com/jaylfc/taOS https://preview.redd.it/u99kicmm6bah1.jpeg?width=2400&format=pjpg&auto=webp&s=47b301ae89fd779c187bbe5eb187e20adb7c08d1
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucke01/vps_deployment_megathread_hermes_agent_june_2026/oultu6u/
+### u/PracticlySpeaking — Addition or operator report
+
+- Score at capture: 1
+- Comment: YA Hermes Setup Guide — [15 Levels Of Hermes Agent from Chatbot To 24/7 Autonomous System](https://x.com/IBuzovskyi/article/2068629714776756339) Getting from install to advanced usage, with suggestions and examples. If you are asking "what can I do with this" it is a worthwhile read. &gt;Most people install Hermes Agent and use it as a chatbot. They type a prompt, get a response, close the tab. That covers maybe 10% of what the agent can do. This article maps every level of Hermes Agent usage, from the first prompt to a system that runs your business without you. 15 levels, grouped into three phases. Each level builds on the one before it, but you can jump to any level that fits your setup.
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucke01/vps_deployment_megathread_hermes_agent_june_2026/ot7yk1z/
+### u/CapMonster1 — Addition or operator report
+
+- Score at capture: 1
+- Comment: Very useful breakdown. I especially agree with the idea that Docker is more of a stability and production optimization, not necessarily the best starting point when you're still experimenting and evolving your setup
+- Source: https://www.reddit.com/r/hermesagent/comments/1ucke01/vps_deployment_megathread_hermes_agent_june_2026/otblhb8/


### PR DESCRIPTION
## Summary

- adds 11 approved r/hermesagent megathreads as maintained Markdown guides
- refreshes the existing Free Models guide as an explicitly historical snapshot
- adds comment-provenance notes containing substantive corrections and durable additions
- expands the README index to all 13 guides
- rewrites the Qwen variant guides to remove unsupported rankings, benchmark claims, and reputational conclusions

## Review and verification

- reviewed all 28 flaired Reddit posts and 775 extracted comments before selecting the migration set
- independent Sparkx/Spark2x content reviews completed; blocking findings repaired and rechecked
- Reddit link validator passed for all guide files
- 234 public external links checked; only expected localhost example endpoints remain unreachable
- use-case catalog reconciled to 240 retained rows across 11 categories
- Markdown table-shape checks and `git diff --check` pass
- privacy/secrets scan found no credentials, private IPs, or Jonathan-specific paths
- commit uses the AtlasOmnia GitHub noreply identity

## Scope

Reddit remains the discussion/archive surface. GitHub becomes the editable source of truth for the selected durable guides. Time-sensitive prices, quotas, model availability, benchmarks, and community claims are date-scoped or marked for verification.